### PR TITLE
Add preferences for currency and language

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "knex": "^3.1.0",
     "react-qr-code": "^2.0.18",
     "react-router-dom": "7.12.0",
-    "sqlite3": "^5.1.7"
+    "sqlite3": "^5.1.7",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config-ts": "3.1.0",

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -26,10 +26,11 @@ import {GetWalletBalance} from "./api/wallet/getWalletBalance";
 import {SetAddressLabel} from "./api/wallet/setAddressLabel";
 import {SelectWallet} from "./api/wallet/selectWallet";
 import {VerifyWalletPasswordHandler} from "./api/wallet/verifyWalletPassword";
-import {UpdatePreferencesHandler} from "./api/updatePreferences";
+import {SetLanguageHandler} from "./api/setLanguage";
 import {Preferences} from "./preferences";
 import {GetPreferencesHandler} from "./api/getPreferences";
 import {ResetPreferencesHandler} from "./api/resetPreferences";
+import {SetFiatCurrencyHandler} from "./api/setFiatCurrency";
 
 export class WalletBackend {
   private walletService?: WalletService
@@ -58,8 +59,9 @@ export class WalletBackend {
     ipcMain.handle('getBlockByHash', new GetBlockByHash(this.walletService).handle)
     ipcMain.handle('setAddressLabel', new SetAddressLabel(this.walletService).handle)
     ipcMain.handle('verifyWalletPassword', new VerifyWalletPasswordHandler(this.walletService).handle)
-    ipcMain.handle('updatePreferences', new UpdatePreferencesHandler(this.preferences).handle)
     ipcMain.handle('getPreferences', new GetPreferencesHandler(this.preferences).handle)
+    ipcMain.handle('setLanguage', new SetLanguageHandler(this.preferences).handle)
+    ipcMain.handle('setFiatCurrency', new SetFiatCurrencyHandler(this.preferences).handle)
     ipcMain.handle('resetPreferences', new ResetPreferencesHandler(this.preferences).handle)
   }
 

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -1,7 +1,7 @@
 import {calibratePBKDF2Iterations, ensureHomeFolder, getKnex, migrateKnex} from './utils'
 import path from 'path'
 import os from 'os'
-import {HomeFolderName, PBKDF2_TARGET_MS, StorageFilename} from './constants'
+import {HomeFolderName, PBKDF2_TARGET_MS, PreferencesFilename, StorageFilename} from './constants'
 import { DashPlatformSDK } from 'dash-platform-sdk'
 import { ipcMain } from 'electron'
 import { WalletDAO } from './database/WalletDAO'
@@ -26,14 +26,19 @@ import {GetWalletBalance} from "./api/wallet/getWalletBalance";
 import {SetAddressLabel} from "./api/wallet/setAddressLabel";
 import {SelectWallet} from "./api/wallet/selectWallet";
 import {VerifyWalletPasswordHandler} from "./api/wallet/verifyWalletPassword";
+import {UpdatePreferencesHandler} from "./api/updatePreferences";
+import {Preferences} from "./preferences";
+import {GetPreferencesHandler} from "./api/getPreferences";
+import {ResetPreferencesHandler} from "./api/resetPreferences";
 
 export class WalletBackend {
   private walletService?: WalletService
   private addressesService?: AddressesService
   private applicationService?: ApplicationService
+  private preferences?: Preferences
 
   private initHandlers(): void {
-    if (!this.walletService || !this.addressesService || !this.applicationService) {
+    if (!this.walletService || !this.addressesService || !this.applicationService || !this.preferences) {
       throw new Error('Services not initialized. Call start() first.')
     }
 
@@ -53,6 +58,9 @@ export class WalletBackend {
     ipcMain.handle('getBlockByHash', new GetBlockByHash(this.walletService).handle)
     ipcMain.handle('setAddressLabel', new SetAddressLabel(this.walletService).handle)
     ipcMain.handle('verifyWalletPassword', new VerifyWalletPasswordHandler(this.walletService).handle)
+    ipcMain.handle('updatePreferences', new UpdatePreferencesHandler(this.preferences).handle)
+    ipcMain.handle('getPreferences', new GetPreferencesHandler(this.preferences).handle)
+    ipcMain.handle('resetPreferences', new ResetPreferencesHandler(this.preferences).handle)
   }
 
   async start(): Promise<void> {
@@ -61,8 +69,7 @@ export class WalletBackend {
     // calibrate only on start and then using until wallet running
     const calibratedIterations = calibratePBKDF2Iterations(PBKDF2_TARGET_MS)
 
-    // Uncomment when we start using preferences
-    // const preferences = await Preferences.init(path.join(os.homedir(), HomeFolderName, PreferencesFilename))
+    const preferences = await Preferences.init(path.join(os.homedir(), HomeFolderName, PreferencesFilename))
 
     const knex = getKnex(path.join(os.homedir(), HomeFolderName, StorageFilename))
 
@@ -77,6 +84,7 @@ export class WalletBackend {
     this.applicationService = new ApplicationService()
     this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, dashPlatformSDK, calibratedIterations)
     this.addressesService = new AddressesService(walletDAO, addressDAO)
+    this.preferences = preferences
 
     this.initHandlers()
 

--- a/src/main/src/api/getPreferences.ts
+++ b/src/main/src/api/getPreferences.ts
@@ -1,0 +1,14 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import {Preferences, PreferencesJSON} from "../preferences";
+
+export class GetPreferencesHandler {
+  private preferences: Preferences
+
+  constructor(preferences: Preferences) {
+    this.preferences = preferences
+  }
+
+  handle = async (_event: IpcMainInvokeEvent): Promise<PreferencesJSON> => {
+    return this.preferences.toJSON()
+  }
+}

--- a/src/main/src/api/resetPreferences.ts
+++ b/src/main/src/api/resetPreferences.ts
@@ -1,0 +1,29 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import {Preferences} from "../preferences";
+import {QueryStatus} from "../types/QueryStatus";
+import {ZodError} from "zod";
+
+export class ResetPreferencesHandler {
+  private preferences: Preferences
+
+  constructor(preferences: Preferences) {
+    this.preferences = preferences
+  }
+
+  handle = async (_event: IpcMainInvokeEvent): Promise<QueryStatus> => {
+    try {
+      const defaults = Preferences.default()
+      console.log(defaults)
+      await this.preferences.apply(defaults.toJSON())
+
+      return {success: true, errorMessage: null}
+    } catch (err) {
+      let message: string = (err as Error).message
+
+      if (err instanceof ZodError) {
+        message = err.issues.map(issue => issue.message).join(', ')
+      }
+      return {success: false, errorMessage: message}
+    }
+  }
+}

--- a/src/main/src/api/setFiatCurrency.ts
+++ b/src/main/src/api/setFiatCurrency.ts
@@ -3,16 +3,23 @@ import {Preferences} from "../preferences";
 import {QueryStatus} from "../types/QueryStatus";
 import {ZodError} from "zod";
 
-export class UpdatePreferencesHandler {
+export class SetFiatCurrencyHandler {
   private preferences: Preferences
 
   constructor(preferences: Preferences) {
     this.preferences = preferences
   }
 
-  handle = async (_event: IpcMainInvokeEvent, preferences: unknown): Promise<QueryStatus> => {
+  handle = async (_event: IpcMainInvokeEvent, currency: string): Promise<QueryStatus> => {
     try {
-      await this.preferences.apply(preferences)
+      await this.preferences.apply({
+        ...this.preferences,
+        general: {
+          ...this.preferences.general,
+          currency,
+        }
+      })
+
 
       return {success: true, errorMessage: null}
     } catch (err) {

--- a/src/main/src/api/setLanguage.ts
+++ b/src/main/src/api/setLanguage.ts
@@ -1,0 +1,34 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import {Preferences} from "../preferences";
+import {QueryStatus} from "../types/QueryStatus";
+import {ZodError} from "zod";
+
+export class SetLanguageHandler {
+  private preferences: Preferences
+
+  constructor(preferences: Preferences) {
+    this.preferences = preferences
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, language: string): Promise<QueryStatus> => {
+    try {
+      await this.preferences.apply({
+        ...this.preferences,
+        general: {
+          ...this.preferences.general,
+          language,
+        }
+      })
+
+
+      return {success: true, errorMessage: null}
+    } catch (err) {
+      let message: string = (err as Error).message
+
+      if (err instanceof ZodError) {
+        message = err.issues.map(issue => issue.message).join(', ')
+      }
+      return {success: false, errorMessage: message}
+    }
+  }
+}

--- a/src/main/src/api/updatePreferences.ts
+++ b/src/main/src/api/updatePreferences.ts
@@ -1,0 +1,27 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import {Preferences} from "../preferences";
+import {QueryStatus} from "../types/QueryStatus";
+import {ZodError} from "zod";
+
+export class UpdatePreferencesHandler {
+  private preferences: Preferences
+
+  constructor(preferences: Preferences) {
+    this.preferences = preferences
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, preferences: unknown): Promise<QueryStatus> => {
+    try {
+      await this.preferences.apply(preferences)
+
+      return {success: true, errorMessage: null}
+    } catch (err) {
+      let message: string = (err as Error).message
+
+      if (err instanceof ZodError) {
+        message = err.issues.map(issue => issue.message).join(', ')
+      }
+      return {success: false, errorMessage: message}
+    }
+  }
+}

--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -8,3 +8,13 @@ export const PBKDF2_KEY_LENGTH = 32
 export const PBKDF2_DIGEST = 'sha512'
 export const PBKDF2_SALT_LENGTH = 32
 export const PBKDF2_TARGET_MS = 200
+
+export const SUPPORTED_LANGUAGES = [
+  "en",
+]
+
+export const SUPPORTED_CURRENCIES = [
+  "usd",
+  "btc",
+  "rub"
+]

--- a/src/main/src/preferences/general.ts
+++ b/src/main/src/preferences/general.ts
@@ -1,7 +1,12 @@
-export interface GeneralPreferencesJSON {
-  language: string
-  currency: string
-}
+import {z} from 'zod'
+import {SUPPORTED_CURRENCIES, SUPPORTED_LANGUAGES} from "../constants";
+
+export const GeneralPreferencesSchema = z.object({
+  language: z.enum(SUPPORTED_LANGUAGES),
+  currency: z.enum(SUPPORTED_CURRENCIES),
+})
+
+export type GeneralPreferencesJSON = z.infer<typeof GeneralPreferencesSchema>
 
 export class GeneralPreferences {
   language: string
@@ -19,11 +24,12 @@ export class GeneralPreferences {
     }
   }
 
-  static fromObject({language, currency}: GeneralPreferencesJSON): GeneralPreferences {
+  static fromObject(value: unknown): GeneralPreferences {
+    const {language, currency} = GeneralPreferencesSchema.parse(value)
     return new GeneralPreferences(language, currency)
   }
 
   static default(): GeneralPreferences {
-    return new GeneralPreferences('en', 'USD')
+    return new GeneralPreferences('en', 'usd')
   }
 }

--- a/src/main/src/preferences/index.ts
+++ b/src/main/src/preferences/index.ts
@@ -1,10 +1,12 @@
 import fs from "fs/promises";
-import {GeneralPreferences, GeneralPreferencesJSON} from "./general";
+import {z} from 'zod'
+import {GeneralPreferences, GeneralPreferencesJSON, GeneralPreferencesSchema} from "./general";
 
-interface PreferencesData {
-  version: number
-  general: GeneralPreferencesJSON
-}
+export const PreferencesSchema = z.object({
+  general: GeneralPreferencesSchema,
+})
+
+export type PreferencesJSON = z.infer<typeof PreferencesSchema> & { version: number }
 
 export class Preferences {
   static readonly CURRENT_VERSION = 1
@@ -98,13 +100,28 @@ export class Preferences {
     return preferences
   }
 
-  toJSON(): PreferencesData {
+  toJSON(): PreferencesJSON {
     return {
       version: this.version,
       general: this.general.toJSON(),
     }
   }
 
+  /**
+   * Update preferences instance with passed values and save on disk.
+   * @param value
+   */
+  async apply(value: unknown): Promise<void> {
+    const {general} = PreferencesSchema.parse(value)
+
+    this.general = GeneralPreferences.fromObject(general)
+
+    await this.update()
+  }
+
+  /**
+   * Save preferencess to selected folder
+   */
   async update(): Promise<void> {
     if (this.path != null) {
       await fs.writeFile(this.path, JSON.stringify(this))
@@ -120,10 +137,12 @@ export class Preferences {
     return instance
   }
 
-  static fromObject({version, general}: PreferencesData): Preferences {
+  static fromObject(value: unknown): Preferences {
+    const {general} = PreferencesSchema.parse(value)
+
     const instance = new Preferences()
 
-    instance.version = version
+    instance.version = Preferences.CURRENT_VERSION
     instance.general = GeneralPreferences.fromObject(general)
 
     return instance

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -15,7 +15,9 @@ export const apiDefinitions = (ipcRenderer) => ({
   getIdentityBalance: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityBalance', identifier),
   getIdentityNonce: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityNonce', identifier),
   setAddressLabel: (walletId: string, address: string, label: string) => ipcRenderer.invoke('setAddressLabel', walletId, address, label),
+  // preferencess
   getPreferences: () => ipcRenderer.invoke('getPreferences'),
-  updatePreferences: (preferences: unknown) => ipcRenderer.invoke('updatePreferences', preferences),
+  setLanguage: (language: string) => ipcRenderer.invoke('setLanguage', language),
+  setFiatCurrency: (currency: string) => ipcRenderer.invoke('setFiatCurrency', currency),
   resetPreferences: () => ipcRenderer.invoke('resetPreferences')
 })

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -15,4 +15,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   getIdentityBalance: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityBalance', identifier),
   getIdentityNonce: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityNonce', identifier),
   setAddressLabel: (walletId: string, address: string, label: string) => ipcRenderer.invoke('setAddressLabel', walletId, address, label),
+  getPreferences: () => ipcRenderer.invoke('getPreferences'),
+  updatePreferences: (preferences: unknown) => ipcRenderer.invoke('updatePreferences', preferences),
+  resetPreferences: () => ipcRenderer.invoke('resetPreferences')
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6789,3 +6789,8 @@ yocto-queue@^0.1.0:
   version "4.3.5"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz"
   integrity sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==
+
+zod@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.3.6.tgz#89c56e0aa7d2b05107d894412227087885ab112a"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
# Issue
We need to add ipc handlers which allows to:
- read preferences
- update preferences
- reset preferences

# Things done
- Implemented read, update, reset preferences
- Added `zod` for validation preferences object
- Updated definitions and wallet backend for new handlers with preferencess