### PR TITLE
Do not publish with electron-builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "dev": "electron-vite dev",
     "build": "npm run typecheck && electron-vite build",
     "typecheck": "tsc --noEmit -p tsconfig.node.json && tsc --noEmit -p tsconfig.web.json",
-    "build:win": "npm run build && electron-builder --win",
-    "build:mac": "npm run build && electron-builder --mac",
-    "build:linux": "npm run build && electron-builder --linux",
+    "build:win": "npm run build && electron-builder --win --publish never",
+    "build:mac": "npm run build && electron-builder --mac --publish never",
+    "build:linux": "npm run build && electron-builder --linux --publish never",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
# Issue

We are manually uploading binary assets with softprops github actions, so internal electron-builder publisher is not needed

# Things done
* Added --publish never to binary build scripts in npm