### PR TITLE
Fix startup errors

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { app, shell, BrowserWindow, ipcMain, nativeTheme } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, nativeTheme, dialog } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/logo.png?asset'
@@ -65,13 +65,21 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
-  createWindow()
-
-  backend.start().catch(console.error)
+  backend.start()
+    .then(createWindow)
+    .catch((err) => {
+      console.error(err)
+      dialog.showErrorBox('Startup failed', String(err))
+    })
 
   app.on('activate', () => {
     if (mainWindow === null) {
-      createWindow()
+      backend.start()
+        .then(createWindow)
+        .catch((err) => {
+          console.error(err)
+          dialog.showErrorBox('Startup failed', String(err))
+        })
     }
   })
 })

--- a/src/main/src/utils.ts
+++ b/src/main/src/utils.ts
@@ -7,8 +7,8 @@ import * as migration0000 from '../migrations/0000_init'
 import * as migration0001 from '../migrations/0001_identities'
 
 const migrations = [
-  { name: '0000_init', migration: migration0000 },
-  { name: '0001_identities', migration: migration0001 },
+  { name: '0000_init.ts', migration: migration0000 },
+  { name: '0001_identities.ts', migration: migration0001 },
 ]
 
 const inlineMigrationSource = {

--- a/src/renderer/src/components/pages/auth/CreateWallet.tsx
+++ b/src/renderer/src/components/pages/auth/CreateWallet.tsx
@@ -53,6 +53,7 @@ function getPasswordValidationError(password: string): string | null {
 export default function  CreateWallet({ password, setPassword, generateSeedPhrase, createImportedWallet, data } : CreateWalletProps): React.JSX.Element {
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
   const { theme } = useTheme()
   const iconColor = theme === 'dark' ? '#ffffff' : ''
 
@@ -71,9 +72,10 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
       toast.error(msg)
       return
     }
+    setLoading(true)
     try {
       if (createImportedWallet) {
-        createImportedWallet()
+        await createImportedWallet()
       } else {
         if (generateSeedPhrase) {
           await generateSeedPhrase()
@@ -87,6 +89,8 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
           : errorMessage
       setError(message)
       toast.error(errorTitle + " " + message)
+    } finally {
+      setLoading(false)
     }
   }
 
@@ -145,7 +149,7 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
         colorScheme={"primary"}
         size={"md"}
         className={"rounded-[.9375rem] p-4.5"}
-        disabled={tooShortOrEmpty}
+        disabled={tooShortOrEmpty || loading}
       >
         {data.buttonNext}
       </Button>

--- a/src/renderer/src/hooks/useCreateWallet.ts
+++ b/src/renderer/src/hooks/useCreateWallet.ts
@@ -61,7 +61,7 @@ export interface TypeUseCreateWallet {
   goToPassword: () => void
   goToImportSeedPhrase: () => void
   submitImportSeedPhrase: (phrase: string[]) => void
-  createImportedWallet: () => void
+  createImportedWallet: () => Promise<void>
 }
 
 const PREV_STEP: Partial<Record<CreateWalletStep, CreateWalletStep>> = {
@@ -176,14 +176,14 @@ export function useCreateWallet(): TypeUseCreateWallet {
     setImportSeedPhrase(true)
   }, [setImportSeedPhrase])
 
-  const createImportedWallet = useCallback(() => {
-    API.createWallet(importedSeedPhrase.join(' '), network, password)
-    .then(() => setStep('success'))
-    .catch((err) => {
-      console.error('createWallet failed:', err)
-      const message = err instanceof Error ? err.message : couldNotCreateWallet
-      toast.error(couldNotCreateWallet + " " + message)
-    })
+  const createImportedWallet = useCallback((): Promise<void> => {
+    return API.createWallet(importedSeedPhrase.join(' '), network, password)
+      .then(() => setStep('success'))
+      .catch((err) => {
+        console.error('createWallet failed:', err)
+        const message = err instanceof Error ? err.message : couldNotCreateWallet
+        toast.error(couldNotCreateWallet + " " + message)
+      })
   }, [importedSeedPhrase, network, password])
 
   const submitImportSeedPhrase = useCallback((phrase: string[]) => {


### PR DESCRIPTION
# Issue

Due incorrect inline migrations path in the source code database wasn't able execute migrations and create wallet was failing with no handler for createWallet error

There was couple of things I fixed, plus disabled a Next button after you pressed on Create Password screen

* Fixed `.ts` path in migrations
* Added error message to renderer if WalletBackend failed to start
* On Create Password, Next button is now disabled after pressing