### PR TITLE
Include OS in dist binary filename

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -19,7 +19,7 @@ win:
       arch:
         - x64
 nsis:
-  artifactName: ${name}-${version}-setup.${ext}
+  artifactName: ${name}-${version}-${os}-${arch}-setup.${ext}
   shortcutName: ${productName}
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
@@ -30,7 +30,7 @@ mac:
         - arm64
         - x64
 dmg:
-  artifactName: ${name}-${version}-${arch}.${ext}
+  artifactName: ${name}-${version}-${os}-${arch}.${ext}
 linux:
   target:
     - target: AppImage
@@ -42,7 +42,9 @@ linux:
   maintainer: pshenmic.dev
   category: Office;Finance;
 appImage:
-  artifactName: ${name}-${version}.${ext}
+  artifactName: ${name}-${version}-${os}-${arch}.${ext}
+deb:
+  artifactName: ${name}-${version}-${os}-${arch}.${ext}
 #  entitlementsInherit: build/entitlements.mac.plist
 #  extendInfo:
 #    - NSCameraUsageDescription: Application requests access to the device's camera.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-desktop",
-  "version": "0.0.1-dev.5",
+  "version": "0.0.1-dev.6",
   "description": "Desktop wallet (cross-platform) for Dash network",
   "main": "./out/main/index.js",
   "author": "pshenmic",


### PR DESCRIPTION
# Issue

Executable filenames of dist releases wasn't including OS and was a bit confusing in the assets of the release.

It should now include it, f.e.:

  - dash-desktop-1.0.0-win-x64-setup.exe
  - dash-desktop-1.0.0-mac-arm64.dmg
  - dash-desktop-1.0.0-linux-x64.AppImage
  - dash-desktop-1.0.0-linux-x64.deb



# Things done

* Added OS in dist filenames
* Bumped version