### PR TITLE
Fix Receive tab and improve wallet tab data loading

### DIFF
--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -13,6 +13,7 @@ import { ApplicationService } from './services/ApplicationService'
 import {Preferences} from "./preferences";
 import { CreateWalletHandler } from './api/wallet/createWallet'
 import { GetWalletAddressesHandler } from './api/wallet/getAddresses'
+import { GetReceiveAddressHandler } from './api/wallet/getReceiveAddress'
 import { GetStatusHandler } from './api/getStatus'
 import { GetAllWalletsHandler } from './api/wallet/getAllWallets'
 import { GetTransactionsHandler } from './api/wallet/getTransactions'
@@ -56,6 +57,7 @@ export class WalletBackend {
     ipcMain.handle('selectWallet', new SelectWallet(this.walletService).handle)
     ipcMain.handle('getWalletBalance', new GetWalletBalance(this.walletService).handle)
     ipcMain.handle('getAddresses', new GetWalletAddressesHandler(this.walletService).handle)
+    ipcMain.handle('getReceiveAddress', new GetReceiveAddressHandler(this.walletService).handle)
     ipcMain.handle('getStatus', new GetStatusHandler(this.walletService, this.applicationService, this.walletSyncService).handle)
     ipcMain.handle('getTransactions', new GetTransactionsHandler(this.walletService).handle)
     ipcMain.handle('getBalance', new GetBalance(this.walletService).handle)

--- a/src/main/src/api/wallet/getReceiveAddress.ts
+++ b/src/main/src/api/wallet/getReceiveAddress.ts
@@ -1,0 +1,14 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { WalletService } from '../../services/WalletService'
+
+export class GetReceiveAddressHandler {
+  private walletService: WalletService
+
+  constructor(walletService: WalletService) {
+    this.walletService = walletService
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, walletId: string): Promise<string> => {
+    return this.walletService.getReceiveAddress(walletId)
+  }
+}

--- a/src/main/src/providers/InsightWalletProvider.ts
+++ b/src/main/src/providers/InsightWalletProvider.ts
@@ -107,9 +107,13 @@ export class InsightWalletProvider implements WalletProvider {
     return data.txid
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async nextUnusedAddress(_addresses: string[]): Promise<string> {
-    throw new Error('Not implemented')
+  // TODO: walk receiving addresses and return the first one with no on-chain
+  // history via the Insight API. For the first release we just return the
+  // first receiving address.
+  async nextUnusedAddress(): Promise<string> {
+    const { receiving } = await this.addressDAO.getAddressesByWalletId(this.walletId)
+    if (receiving.length === 0) throw new Error('Wallet has no receiving addresses')
+    return receiving[0].address
   }
 
   private async allWalletAddresses() {

--- a/src/main/src/providers/InsightWalletProvider.ts
+++ b/src/main/src/providers/InsightWalletProvider.ts
@@ -1,4 +1,5 @@
 import {Block, Script, Transaction as SDKTransaction} from 'dash-core-sdk'
+import { net } from 'electron'
 import {UTXO} from '../types/UTXO'
 import {WalletProvider} from './WalletProvider'
 import {Network} from '../types'
@@ -34,7 +35,7 @@ export class InsightWalletProvider implements WalletProvider {
   }
 
   async sendRequest(url: string, params?: RequestInit): Promise<Response> {
-    const response = await fetch(url, params)
+    const response = await net.fetch(url, params as RequestInit)
 
     if (!response.ok) {
       throw new Error(`Insight API error: ${response.status}`)
@@ -104,6 +105,11 @@ export class InsightWalletProvider implements WalletProvider {
     const data = await response.json() as { txid: string }
 
     return data.txid
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async nextUnusedAddress(_addresses: string[]): Promise<string> {
+    throw new Error('Not implemented')
   }
 
   private async allWalletAddresses() {

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -2,6 +2,7 @@ import {Block, Script, utils as sdkUtils} from 'dash-core-sdk'
 import {UTXO} from '../types/UTXO'
 import {Transaction} from '../types/Transaction'
 import {TransactionDAO} from '../database/TransactionDAO'
+import {AddressDAO} from '../database/AddressDAO'
 import {WalletProvider} from './WalletProvider'
 
 const {addressToPublicKeyHash} = sdkUtils
@@ -16,6 +17,7 @@ export class P2PWalletProvider implements WalletProvider {
   constructor(
     private readonly transactionDAO: TransactionDAO,
     private readonly walletId: string,
+    private readonly addressDAO: AddressDAO,
   ) {}
 
   async getTransactions(address: string): Promise<Transaction[]> {
@@ -51,9 +53,12 @@ export class P2PWalletProvider implements WalletProvider {
     throw new Error('Unimplemented: getBlockByHash is not available in p2p mode')
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  async nextUnusedAddress(_addresses: string[]): Promise<string> {
-    throw new Error('Not implemented')
+  // TODO: derive "unused" from the local SPV-synced tx store. For the first
+  // release we just return the first receiving address.
+  async nextUnusedAddress(): Promise<string> {
+    const { receiving } = await this.addressDAO.getAddressesByWalletId(this.walletId)
+    if (receiving.length === 0) throw new Error('Wallet has no receiving addresses')
+    return receiving[0].address
   }
 
   private p2pkhScript(address: string): Script {

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -51,6 +51,11 @@ export class P2PWalletProvider implements WalletProvider {
     throw new Error('Unimplemented: getBlockByHash is not available in p2p mode')
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async nextUnusedAddress(_addresses: string[]): Promise<string> {
+    throw new Error('Not implemented')
+  }
+
   private p2pkhScript(address: string): Script {
     const s = new Script()
     s.pushOpCode('OP_DUP')

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -2,7 +2,6 @@ import {Block, Script, utils as sdkUtils} from 'dash-core-sdk'
 import {UTXO} from '../types/UTXO'
 import {Transaction} from '../types/Transaction'
 import {TransactionDAO} from '../database/TransactionDAO'
-import {AddressDAO} from '../database/AddressDAO'
 import {WalletProvider} from './WalletProvider'
 
 const {addressToPublicKeyHash} = sdkUtils
@@ -17,7 +16,6 @@ export class P2PWalletProvider implements WalletProvider {
   constructor(
     private readonly transactionDAO: TransactionDAO,
     private readonly walletId: string,
-    private readonly addressDAO: AddressDAO,
   ) {}
 
   async getTransactions(address: string): Promise<Transaction[]> {
@@ -53,12 +51,8 @@ export class P2PWalletProvider implements WalletProvider {
     throw new Error('Unimplemented: getBlockByHash is not available in p2p mode')
   }
 
-  // TODO: derive "unused" from the local SPV-synced tx store. For the first
-  // release we just return the first receiving address.
   async nextUnusedAddress(): Promise<string> {
-    const { receiving } = await this.addressDAO.getAddressesByWalletId(this.walletId)
-    if (receiving.length === 0) throw new Error('Wallet has no receiving addresses')
-    return receiving[0].address
+    throw new Error('Not implemented')
   }
 
   private p2pkhScript(address: string): Script {

--- a/src/main/src/providers/WalletProvider.ts
+++ b/src/main/src/providers/WalletProvider.ts
@@ -9,8 +9,11 @@ export interface WalletProvider {
   getBlockByHash(hash: string): Promise<Block>
   getUTXOs(address: string): Promise<UTXO[]>
   broadcastTx(tx: SDKTransaction): Promise<string>
-  // Returns the first address from the given set that has no on-chain history
-  // — used by Receive (next unused receiving address) and change-output
-  // selection. Determined by the provider, not by local DB state.
-  nextUnusedAddress(addresses: string[]): Promise<string>
+  // Returns the next unused receiving address for the wallet — used by the
+  // Receive tab and change-output selection. The provider decides what
+  // "unused" means against its source of truth (chain state via API,
+  // local SPV-synced DB, etc.). For the first release this is simplified
+  // to "the first receiving address"; full chain-history iteration is a
+  // follow-up.
+  nextUnusedAddress(): Promise<string>
 }

--- a/src/main/src/providers/WalletProvider.ts
+++ b/src/main/src/providers/WalletProvider.ts
@@ -9,4 +9,8 @@ export interface WalletProvider {
   getBlockByHash(hash: string): Promise<Block>
   getUTXOs(address: string): Promise<UTXO[]>
   broadcastTx(tx: SDKTransaction): Promise<string>
+  // Returns the first address from the given set that has no on-chain history
+  // — used by Receive (next unused receiving address) and change-output
+  // selection. Determined by the provider, not by local DB state.
+  nextUnusedAddress(addresses: string[]): Promise<string>
 }

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -87,7 +87,7 @@ export class WalletService {
 
   private getProvider(walletId: string, network: Network): WalletProvider {
     if (this.applicationService.preferences.general.connectionType === 'p2p') {
-      return new P2PWalletProvider(this.transactionDAO, walletId)
+      return new P2PWalletProvider(this.transactionDAO, walletId, this.addressDAO)
     }
     return new InsightWalletProvider(network, walletId, this.addressDAO)
   }
@@ -248,9 +248,8 @@ export class WalletService {
     const wallet = await this.walletDAO.getWalletById(walletId)
     if (wallet == null) throw new Error('Wallet not found')
 
-    const { receiving } = await this.addressDAO.getAddressesByWalletId(walletId)
     const provider = this.getProvider(wallet.walletId, wallet.network)
-    return provider.nextUnusedAddress(receiving.map(a => a.address))
+    return provider.nextUnusedAddress()
   }
 
   async getAddressesByWalletId(walletId: string): Promise<GroupedAddresses> {

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -244,6 +244,15 @@ export class WalletService {
     return this.addressDAO.setAddressLabel(walletId, address, label)
   }
 
+  async getReceiveAddress(walletId: string): Promise<string> {
+    const wallet = await this.walletDAO.getWalletById(walletId)
+    if (wallet == null) throw new Error('Wallet not found')
+
+    const { receiving } = await this.addressDAO.getAddressesByWalletId(walletId)
+    const provider = this.getProvider(wallet.walletId, wallet.network)
+    return provider.nextUnusedAddress(receiving.map(a => a.address))
+  }
+
   async getAddressesByWalletId(walletId: string): Promise<GroupedAddresses> {
     const wallet = await this.walletDAO.getWalletById(walletId)
 

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -87,7 +87,7 @@ export class WalletService {
 
   private getProvider(walletId: string, network: Network): WalletProvider {
     if (this.applicationService.preferences.general.connectionType === 'p2p') {
-      return new P2PWalletProvider(this.transactionDAO, walletId, this.addressDAO)
+      return new P2PWalletProvider(this.transactionDAO, walletId)
     }
     return new InsightWalletProvider(network, walletId, this.addressDAO)
   }

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -3,6 +3,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   deleteWallet: (walletId: string) => ipcRenderer.invoke('deleteWallet', walletId),
   verifyWalletPassword: (walletId: string, password: string) => ipcRenderer.invoke('verifyWalletPassword', walletId, password),
   getAddresses: (walletId: string) => ipcRenderer.invoke('getAddresses', walletId),
+  getReceiveAddress: (walletId: string) => ipcRenderer.invoke('getReceiveAddress', walletId),
   getStatus: () => ipcRenderer.invoke('getStatus'),
   selectWallet: (walletId: string) => ipcRenderer.invoke('selectWallet', walletId),
   getAllWallets: () => ipcRenderer.invoke('getAllWallets'),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -8,6 +8,7 @@ declare global {
       createWallet: (seedphrase: string, network: string, password: string) => Promise<unknown>
       verifyWalletPassword: (walletId: string, password: string) => Promise<boolean>
       getAddresses: (walletId: string) => Promise<unknown>
+      getReceiveAddress: (walletId: string) => Promise<string | null>
       getStatus: () => Promise<unknown>
       getAllWallets: () => Promise<unknown>
       getTransactions: (walletId: string) => Promise<unknown>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -11,6 +11,10 @@ export class API {
     return this.api.getAddresses(walletId)
   }
 
+  static async getReceiveAddress(walletId: string): Promise<string | null> {
+    return this.api.getReceiveAddress(walletId)
+  }
+
   static async getStatus() {
     return this.api.getStatus()
   }

--- a/src/renderer/src/components/pages/auth/ImportSeedPhrase.tsx
+++ b/src/renderer/src/components/pages/auth/ImportSeedPhrase.tsx
@@ -4,9 +4,10 @@ import { Button, Text } from "@renderer/components/dash-ui-kit-enxtended"
 import { Switch } from "dash-ui-kit/react"
 import { BaseTexts, ImportSeedPhraseTexts } from "@renderer/constants"
 import { TypeUseCreateWallet, WordCount } from "@renderer/hooks/useCreateWallet"
-import { validateMnemonic } from '@scure/bip39'
 import { wordlist } from '@scure/bip39/wordlists/english.js'
 import { toast } from "@renderer/components/ui/Toast"
+
+const WORDLIST_SET = new Set(wordlist)
 
 type ImportSeedPhraseData = Pick<ImportSeedPhraseTexts, 'buttonContinue'> & {
   seedPhraseWarning: BaseTexts
@@ -67,10 +68,9 @@ export default function ImportSeedPhrase({ submitImportSeedPhrase, data }: Impor
   words.length === wordCount &&
   words.every((w) => w.trim().length > 0)
 
-  const isMnemonicValid = validateMnemonic(
-    words.map((w) => w.trim().toLowerCase()).join(' '),
-    wordlist
-  )
+  const isMnemonicValid =
+    words.length === wordCount &&
+    words.every((w) => WORDLIST_SET.has(w.trim().toLowerCase()))
 
   const handleContinue = () => {
     if (!isMnemonicValid) {

--- a/src/renderer/src/components/pages/receive/Page.tsx
+++ b/src/renderer/src/components/pages/receive/Page.tsx
@@ -1,6 +1,9 @@
 import { ReceivePageType } from "@renderer/constants";
 import Header from "../transfer/Header";
 import ReceiveAddressCard from "./ReceiveAddressCard";
+import { useAuth } from "@renderer/contexts/AuthContext";
+import { API } from "@renderer/api";
+import { useAsyncWithCache } from "@renderer/hooks/useAsyncWithCache";
 
 const selectedAsset = {
   id: 'dash',
@@ -11,6 +14,16 @@ const selectedAsset = {
 }
 
 export default function Receive({pageData}: {pageData: ReceivePageType}): React.JSX.Element {
+  const { status } = useAuth()
+  const walletId = status?.selectedWalletId ?? undefined
+  const { data: address } = useAsyncWithCache<string | null>(
+    'receiveAddress',
+    walletId,
+    () => API.getReceiveAddress(walletId!),
+    null,
+    { errorMessage: 'Failed to load receive address' }
+  )
+
   return (
     <div className={`relative flex flex-col pb-12`}>
         <Header data={{...pageData.header, description:
@@ -21,7 +34,7 @@ export default function Receive({pageData}: {pageData: ReceivePageType}): React.
            </span>}}
           selectedAsset={selectedAsset}
         />
-        <ReceiveAddressCard address={'Xk81u1LoHtvMATkD1DStguNYbNRHeXvs9d'} data={pageData.receiveAddressCard} />
+        {address && <ReceiveAddressCard address={address} data={pageData.receiveAddressCard} />}
     </div>
   )
 }

--- a/src/renderer/src/hooks/useAdresses.tsx
+++ b/src/renderer/src/hooks/useAdresses.tsx
@@ -1,40 +1,21 @@
-import { useEffect, useState } from 'react'
+import { useMemo } from 'react'
 import { API } from '@renderer/api'
 import { GetAddressesResponse, WalletAddressDto } from '@renderer/api/types'
+import { useAsyncWithCache } from './useAsyncWithCache'
+
+type AddressesData = { receiving: WalletAddressDto[]; change: WalletAddressDto[] }
 
 export function useAdresses(walletId: string | undefined) {
-  const [receiving, setReceiving] = useState<WalletAddressDto[]>([])
-  const [change, setChange] = useState<WalletAddressDto[]>([])
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!walletId) {
-      setReceiving([])
-      setChange([])
-      return
-    }
-    let dead = false
-    setLoading(true)
-    setErr(null)
-    API.getAddresses(walletId)
-      .then((data) => {
-        if (dead) return
-        const body = data as GetAddressesResponse
-        setReceiving(body.receiving ?? [])
-        setChange(body.change ?? [])
-      })
-      .catch((e) => {
-        console.error('error', e)
-        if (!dead) setErr(e instanceof Error ? e.message : 'Failed')
-      })
-      .finally(() => {
-        if (!dead) setLoading(false)
-      })
-    return () => {
-      dead = true
-    }
-  }, [walletId])
-
-  return { receiving, change, loading, err }
+  const initial = useMemo<AddressesData>(() => ({ receiving: [], change: [] }), [])
+  const { data, loading, err } = useAsyncWithCache<AddressesData>(
+    'addresses',
+    walletId,
+    () => API.getAddresses(walletId!).then((d) => {
+      const body = d as GetAddressesResponse
+      return { receiving: body.receiving ?? [], change: body.change ?? [] }
+    }),
+    initial,
+    { errorMessage: 'Failed to load addresses' }
+  )
+  return { receiving: data.receiving, change: data.change, loading, err }
 }

--- a/src/renderer/src/hooks/useAsyncWithCache.ts
+++ b/src/renderer/src/hooks/useAsyncWithCache.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef, useState } from 'react'
+
+const cache = new Map<string, unknown>()
+
+export interface UseAsyncWithCacheOptions {
+  errorMessage?: string
+}
+
+export function useAsyncWithCache<T>(
+  namespace: string,
+  key: string | undefined,
+  fetcher: () => Promise<T>,
+  initial: T,
+  options?: UseAsyncWithCacheOptions
+): { data: T; loading: boolean; err: string | null } {
+  const cacheKey = key !== undefined ? `${namespace}:${key}` : undefined
+  const cached = cacheKey !== undefined ? (cache.get(cacheKey) as T | undefined) : undefined
+
+  const [data, setData] = useState<T>(cached ?? initial)
+  const [loading, setLoading] = useState(cacheKey !== undefined && cached === undefined)
+  const [err, setErr] = useState<string | null>(null)
+
+  // Keep the latest fetcher in a ref so the effect doesn't have to depend on it,
+  // while still using the freshest closure when (re-)fetching.
+  const fetcherRef = useRef(fetcher)
+  fetcherRef.current = fetcher
+
+  useEffect(() => {
+    if (cacheKey === undefined) {
+      setData(initial)
+      setLoading(false)
+      setErr(null)
+      return
+    }
+
+    let dead = false
+    if (!cache.has(cacheKey)) setLoading(true)
+    setErr(null)
+
+    fetcherRef.current()
+      .then((result) => {
+        // Update the cache even if the component has unmounted, so the next
+        // mount sees fresh data instead of stale cache.
+        cache.set(cacheKey, result)
+        if (dead) return
+        setData(result)
+      })
+      .catch((e) => {
+        console.error(`[${namespace}] fetch failed:`, e)
+        if (!dead) {
+          setErr(options?.errorMessage ?? (e instanceof Error ? e.message : 'Failed'))
+        }
+      })
+      .finally(() => {
+        if (!dead) setLoading(false)
+      })
+
+    return () => { dead = true }
+  }, [cacheKey])
+
+  return { data, loading, err }
+}
+
+export function invalidateAsyncCache(namespace: string, key: string): void {
+  cache.delete(`${namespace}:${key}`)
+}

--- a/src/renderer/src/hooks/useCreateWallet.ts
+++ b/src/renderer/src/hooks/useCreateWallet.ts
@@ -155,7 +155,10 @@ export function useCreateWallet(): TypeUseCreateWallet {
       if (prev === 'verify') setVerifyPhrase([])
       if (prev === 'seed-phrase') {
         setSeedPhrase([])
-        setPassword('')
+        setPasswordState('')
+      }
+      if (prev === 'password' || prev === 'password-import') {
+        setPasswordState('')
       }
       return prevStep
     })

--- a/src/renderer/src/hooks/useIdentities.tsx
+++ b/src/renderer/src/hooks/useIdentities.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react'
 import { API } from '@renderer/api'
+import { useAsyncWithCache } from './useAsyncWithCache'
 
 export type IdentityApiDto = {
   identityIndex: number
@@ -13,36 +13,12 @@ export type IdentityApiDto = {
 }
 
 export function useIdentities(walletId?: string) {
-  const [identities, setIdentities] = useState<IdentityApiDto[]>([])
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-
-  useEffect(() => {
-    if (!walletId) {
-      setIdentities([])
-      return
-    }
-
-    let dead = false
-    setLoading(true)
-    setErr(null)
-
-    API.getIdentities(walletId)
-      .then((data) => {
-        if (dead) return
-        setIdentities((data ?? []) as IdentityApiDto[])
-      })
-      .catch((e) => {
-        if (!dead) setErr(e instanceof Error ? e.message : 'Failed to load identities')
-      })
-      .finally(() => {
-        if (!dead) setLoading(false)
-      })
-
-    return () => {
-      dead = true
-    }
-  }, [walletId])
-
+  const { data: identities, loading, err } = useAsyncWithCache<IdentityApiDto[]>(
+    'identities',
+    walletId,
+    () => API.getIdentities(walletId!).then((d) => (d ?? []) as IdentityApiDto[]),
+    [],
+    { errorMessage: 'Failed to load identities' }
+  )
   return { identities, loading, err }
 }

--- a/src/renderer/src/hooks/useWalletTransactions.tsx
+++ b/src/renderer/src/hooks/useWalletTransactions.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react'
 import { API } from '@renderer/api'
 import { formatCreationDate } from '@renderer/utils/date'
+import { useAsyncWithCache } from './useAsyncWithCache'
 
 export type WalletTxDto = {
   walletId: string
@@ -53,10 +53,7 @@ function groupTransactionsByDay(items: WalletTxItem[]) {
     arr.push(tx)
     map.set(key, arr)
   }
-  return Array.from(map.entries()).map(([label, transactions]) => ({
-    date: label,
-    transactions
-  }))
+  return Array.from(map.entries()).map(([label, transactions]) => ({ date: label, transactions }))
 }
 
 function mapStatus(status: string, confirmations: number): UiStatus {
@@ -67,11 +64,10 @@ function mapStatus(status: string, confirmations: number): UiStatus {
 
 function mapTx(raw: WalletTxDto): WalletTxItem {
   const direction: 'in' | 'out' = raw.direction === 1 ? 'in' : 'out'
-  const rawConfirmations = raw.confirmations
   return {
     id: raw.txid,
-    status: mapStatus(raw.status, rawConfirmations),
-    confirmations: rawConfirmations,
+    status: mapStatus(raw.status, raw.confirmations),
+    confirmations: raw.confirmations,
     kind: 'core',
     blockHeight: raw.blockHeight,
     size: raw.size,
@@ -88,40 +84,13 @@ function mapTx(raw: WalletTxDto): WalletTxItem {
 }
 
 export function useWalletTransactions(walletId: string | undefined) {
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-  const [groups, setGroups] = useState<TransactionGroup[]>([])
-
-  useEffect(() => {
-    if (!walletId) {
-      setGroups([])
-      setErr(null)
-      setLoading(false)
-      return
-    }
-
-    let dead = false
-    setLoading(true)
-    setErr(null)
-
-    API.getTransactions(walletId)
-      .then((raw) => {
-        if(dead) return
-        const items = ((raw ?? []) as WalletTxDto[]).map(mapTx)
-        const groups = groupTransactionsByDay(items)
-        setGroups(groups)
-      })
-      .catch((e) => {
-        console.error('error', e)
-        if (!dead) setErr(e instanceof Error ? e.message : 'Failed')
-      })
-      .finally(() => {
-        if (!dead) setLoading(false)
-      })
-    return () => {
-      dead = true
-    }
-  }, [walletId])
-
+  const { data: groups, loading, err } = useAsyncWithCache<TransactionGroup[]>(
+    'transactions',
+    walletId,
+    () => API.getTransactions(walletId!)
+      .then((raw) => groupTransactionsByDay(((raw ?? []) as WalletTxDto[]).map(mapTx))),
+    [],
+    { errorMessage: 'Failed to load transactions' }
+  )
   return { groups, loading, err }
 }


### PR DESCRIPTION
## Summary

The Receive tab was unusable — it displayed a hardcoded mainnet address (`Xk81u1LoHtvMATkD1DStguNYbNRHeXvs9d`) regardless of the active wallet or network. At the same time, navigating between wallet tabs (Transactions, Addresses, Identities) re-fetched everything from scratch, showing a spinner each time.

This PR wires the Receive tab to the actual wallet through a new provider-level abstraction, and introduces a shared stale-while-revalidate cache for tab data. Several smaller correctness and UX issues are fixed along the way.

## Receive tab

- Removed the hardcoded mainnet address from the Receive page.
- Added IPC endpoint `getReceiveAddress(walletId)`, wired through `WalletService` → `WalletProvider` → handler → preload → renderer `API` → `Receive/Page.tsx`.
- The "which address to show" decision lives on the **provider** (the source of truth for chain state), not in local DB bookkeeping. The new `WalletProvider.nextUnusedAddress(): Promise<string>` method makes this explicit.
- For the first release, `InsightWalletProvider` returns the first receiving address from the wallet (with a `TODO` to walk on-chain history). `P2PWalletProvider` throws `Not implemented` — full SPV-side support is a separate task.

## Tab data caching

A shared hook `useAsyncWithCache(namespace, key, fetcher, initial, options?)` provides stale-while-revalidate behavior for tab data:

- On mount, returns cached value immediately (no spinner), fetches in the background, updates state and cache on success.
- `namespace` prevents collisions when multiple hooks key on the same `walletId`.
- Uses `useRef` for the fetcher to avoid stale-closure issues without retriggering on every render.
- Cache is updated even if the component unmounts before the in-flight fetch resolves, so the next mount sees fresh data instead of stale cache.
- Adopted by `useWalletTransactions`, `useAdresses`, `useIdentities`, and the Receive page address loader.
- Exports `invalidateAsyncCache(namespace, key)` for future manual invalidation (e.g., after `sendCoins`).

## Smaller fixes

- **Create-wallet wizard** — `goBack()` now resets the stored password when navigating back from the password steps, preventing stale passwords from leaking into subsequent attempts.
- **Seed phrase import** — dropped BIP39 checksum validation in favor of plain BIP39 wordlist membership. Some non-standard wallets generate 12-word phrases that pass wordlist checks but fail checksum; the backend already only validates word count, so the frontend was the stricter gate. `WORDLIST_SET` moved to module scope so a 2048-entry `Set` isn't rebuilt on every keystroke.
- **InsightWalletProvider** — switched from global `fetch` (Node/undici) to `electron.net.fetch`. The Node fetch in the Electron main process was unstable with many parallel HTTPS requests (SSL/connection-pool issues); `net.fetch` uses Chromium's networking stack and is the recommended approach for HTTP from the main process.

## Known limitations / follow-ups

- `nextUnusedAddress` returns the first receiving address rather than walking chain history. Privacy-wise this means the address won't rotate between receives until proper "is unused" detection is added.
- Address balances on the Addresses tab reflect **confirmed** funds only (Insight's `/addr/{addr}/balance` endpoint). A freshly received tx is visible on the Transactions tab immediately but won't show in the address balance until first confirmation. Switching to `/addr/{addr}?noTxList=1` to also surface `unconfirmedBalanceSat` is a separate small follow-up.
