### PR TITLE
feat: add setWalletLabel for renaming wallets

### DIFF
--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -26,6 +26,7 @@ import {GetBalance} from "./api/wallet/getBalance";
 import {DeleteWalletHandler} from "./api/wallet/deleteWallet";
 import {GetWalletBalance} from "./api/wallet/getWalletBalance";
 import {SetAddressLabel} from "./api/wallet/setAddressLabel";
+import {SetWalletLabel} from "./api/wallet/setWalletLabel";
 import {SelectWallet} from "./api/wallet/selectWallet";
 import {VerifyWalletPasswordHandler} from "./api/wallet/verifyWalletPassword";
 import {SetLanguageHandler} from "./api/setLanguage";
@@ -67,6 +68,7 @@ export class WalletBackend {
     ipcMain.handle('getIdentityNonce', new GetIdentityNonce(this.walletService).handle)
     ipcMain.handle('getBlockByHash', new GetBlockByHash(this.walletService).handle)
     ipcMain.handle('setAddressLabel', new SetAddressLabel(this.walletService).handle)
+    ipcMain.handle('setWalletLabel', new SetWalletLabel(this.walletService).handle)
     ipcMain.handle('verifyWalletPassword', new VerifyWalletPasswordHandler(this.walletService).handle)
     ipcMain.handle('getPreferences', new GetPreferencesHandler(this.applicationService).handle)
     ipcMain.handle('setLanguage', new SetLanguageHandler(this.applicationService).handle)

--- a/src/main/src/api/wallet/setWalletLabel.ts
+++ b/src/main/src/api/wallet/setWalletLabel.ts
@@ -1,0 +1,15 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { WalletService } from '../../services/WalletService'
+import {QueryStatus} from "../../types/QueryStatus";
+
+export class SetWalletLabel {
+  private walletService: WalletService
+
+  constructor(walletService: WalletService) {
+    this.walletService = walletService
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, walletId: string, label: string | null): Promise<QueryStatus> => {
+    return this.walletService.setWalletLabel(walletId, label)
+  }
+}

--- a/src/main/src/database/WalletDAO.ts
+++ b/src/main/src/database/WalletDAO.ts
@@ -77,6 +77,17 @@ export class WalletDAO {
     return fromRow(rows[0])
   }
 
+  setWalletLabel = async (walletId: string, label: string | null): Promise<QueryStatus> => {
+    const result = await this.knex('wallet')
+      .where('wallet_id', walletId)
+      .update({label})
+
+    if (result > 0) {
+      return {success: true, errorMessage: null}
+    }
+    return {success: false, errorMessage: 'Wallet not found'}
+  }
+
   setSelectedWallet = async (walletId: string): Promise<QueryStatus> => {
     await this.knex('wallet')
       .where('selected', true)

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -244,6 +244,10 @@ export class WalletService {
     return this.addressDAO.setAddressLabel(walletId, address, label)
   }
 
+  async setWalletLabel(walletId: string, label: string | null): Promise<QueryStatus> {
+    return this.walletDAO.setWalletLabel(walletId, label)
+  }
+
   async getReceiveAddress(walletId: string): Promise<string> {
     const wallet = await this.walletDAO.getWalletById(walletId)
     if (wallet == null) throw new Error('Wallet not found')

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -16,6 +16,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   getIdentityBalance: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityBalance', identifier),
   getIdentityNonce: (identifier: string): Promise<bigint> => ipcRenderer.invoke('getIdentityNonce', identifier),
   setAddressLabel: (walletId: string, address: string, label: string) => ipcRenderer.invoke('setAddressLabel', walletId, address, label),
+  setWalletLabel: (walletId: string, label: string | null) => ipcRenderer.invoke('setWalletLabel', walletId, label),
   // preferencess
   getPreferences: () => ipcRenderer.invoke('getPreferences'),
   setLanguage: (language: string) => ipcRenderer.invoke('setLanguage', language),


### PR DESCRIPTION
## Issue
`wallet.label` column has existed in the schema since `0000_init`, but the only writer is `saveWallet` (called once on wallet creation with `label = null`). There was no IPC / DAO method to update it afterwards, so the renderer had no way to let users rename a wallet — the label stayed null forever.

## Done
- `WalletDAO.setWalletLabel(walletId, label: string | null)` — `UPDATE wallet SET label = ? WHERE wallet_id = ?`. Returns `QueryStatus` with `errorMessage: 'Wallet not found'` when 0 rows match. `label: null` is supported to clear the label (column is nullable).
- `WalletService.setWalletLabel` — thin pass-through, mirrors the existing `setAddressLabel` pattern.
- New handler `api/wallet/setWalletLabel.ts`, registered as `ipcMain.handle('setWalletLabel', …)` in `WalletBackend`.
- Exposed as `window.electronAPI.setWalletLabel(walletId, label)` in `preload/definitions.ts`.
