### PR TITLE
feat: add exportMnemonic for seed phrase backup

### DIFF
--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -28,6 +28,7 @@ import {GetWalletBalance} from "./api/wallet/getWalletBalance";
 import {SetAddressLabel} from "./api/wallet/setAddressLabel";
 import {SelectWallet} from "./api/wallet/selectWallet";
 import {VerifyWalletPasswordHandler} from "./api/wallet/verifyWalletPassword";
+import {ExportMnemonicHandler} from "./api/wallet/exportMnemonic";
 import {SetLanguageHandler} from "./api/setLanguage";
 import {GetPreferencesHandler} from "./api/getPreferences";
 import {ResetPreferencesHandler} from "./api/resetPreferences";
@@ -68,6 +69,7 @@ export class WalletBackend {
     ipcMain.handle('getBlockByHash', new GetBlockByHash(this.walletService).handle)
     ipcMain.handle('setAddressLabel', new SetAddressLabel(this.walletService).handle)
     ipcMain.handle('verifyWalletPassword', new VerifyWalletPasswordHandler(this.walletService).handle)
+    ipcMain.handle('exportMnemonic', new ExportMnemonicHandler(this.walletService).handle)
     ipcMain.handle('getPreferences', new GetPreferencesHandler(this.applicationService).handle)
     ipcMain.handle('setLanguage', new SetLanguageHandler(this.applicationService).handle)
     ipcMain.handle('setFiatCurrency', new SetFiatCurrencyHandler(this.applicationService).handle)

--- a/src/main/src/api/wallet/exportMnemonic.ts
+++ b/src/main/src/api/wallet/exportMnemonic.ts
@@ -1,0 +1,14 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { WalletService } from '../../services/WalletService'
+
+export class ExportMnemonicHandler {
+  private walletService: WalletService
+
+  constructor(walletService: WalletService) {
+    this.walletService = walletService
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, walletId: string, password: string): Promise<string> => {
+    return this.walletService.exportMnemonic(walletId, password)
+  }
+}

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -216,11 +216,12 @@ export class WalletService {
       throw new Error('Wallet not found')
     }
 
-    try {
-      return decryptMnemonic(wallet.encryptedMnemonic, password)
-    } catch {
+    const isValid = await this.verifyWalletPassword(walletId, password)
+    if (!isValid) {
       throw new Error('Invalid password')
     }
+
+    return decryptMnemonic(wallet.encryptedMnemonic, password)
   }
 
   async verifyWalletPassword(walletId: string, password: string): Promise<boolean> {

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -210,6 +210,19 @@ export class WalletService {
     return this.walletDAO.setSelectedWallet(walletId)
   }
 
+  async exportMnemonic(walletId: string, password: string): Promise<string> {
+    const wallet = await this.walletDAO.getWalletById(walletId)
+    if (wallet == null) {
+      throw new Error('Wallet not found')
+    }
+
+    try {
+      return decryptMnemonic(wallet.encryptedMnemonic, password)
+    } catch {
+      throw new Error('Invalid password')
+    }
+  }
+
   async verifyWalletPassword(walletId: string, password: string): Promise<boolean> {
     const wallet = await this.walletDAO.getWalletById(walletId)
 

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -2,6 +2,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   createWallet: (seedphrase: string, network: string, password: string) => ipcRenderer.invoke('createWallet', seedphrase, network, password),
   deleteWallet: (walletId: string) => ipcRenderer.invoke('deleteWallet', walletId),
   verifyWalletPassword: (walletId: string, password: string) => ipcRenderer.invoke('verifyWalletPassword', walletId, password),
+  exportMnemonic: (walletId: string, password: string): Promise<string> => ipcRenderer.invoke('exportMnemonic', walletId, password),
   getAddresses: (walletId: string) => ipcRenderer.invoke('getAddresses', walletId),
   getReceiveAddress: (walletId: string) => ipcRenderer.invoke('getReceiveAddress', walletId),
   getStatus: () => ipcRenderer.invoke('getStatus'),


### PR DESCRIPTION
## Issue
After wallet creation the seed phrase is AES-256-GCM-encrypted into `wallet.encrypted_mnemonic` and never surfaced again. Users had no way to back up their seed or import the wallet into a different client — the encrypted blob is useless outside this app + the wallet's password.

## Done
- `WalletService.exportMnemonic(walletId, password): Promise<string>` — looks up the wallet, runs the existing `decryptMnemonic` helper, returns the plaintext seed phrase.
  - Throws `Error('Wallet not found')` for unknown `walletId`.
  - Throws `Error('Invalid password')` when AES-GCM auth tag verification fails — same semantics as `sendCoins`, so the renderer can match by `error.message`.
- New handler `api/wallet/exportMnemonic.ts`, registered as `ipcMain.handle('exportMnemonic', …)` in `WalletBackend`.
- Exposed as `window.electronAPI.exportMnemonic(walletId, password): Promise<string>` in `preload/definitions.ts`.
