### PR TITLE
feat: add RatesService for DASH→USD balance conversion

### DIFF
--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -10,6 +10,7 @@ import { IdentityDAO } from './database/IdentityDAO'
 import { TransactionDAO } from './database/TransactionDAO'
 import { WalletService } from './services/WalletService'
 import { ApplicationService } from './services/ApplicationService'
+import { RatesService } from './services/RatesService'
 import {Preferences} from "./preferences";
 import { CreateWalletHandler } from './api/wallet/createWallet'
 import { GetWalletAddressesHandler } from './api/wallet/getAddresses'
@@ -98,9 +99,11 @@ export class WalletBackend {
     const dashPlatformSDK = new DashPlatformSDK({ network: 'testnet'})
 
 
+    const ratesService = new RatesService()
+
     this.applicationService = new ApplicationService(preferences)
     this.walletSyncService = new WalletSyncService(walletDAO, addressDAO, transactionDAO)
-    this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, transactionDAO, this.applicationService, dashPlatformSDK, calibratedIterations)
+    this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, transactionDAO, this.applicationService, ratesService, dashPlatformSDK, calibratedIterations)
     this.addressDAO = addressDAO
 
     this.initHandlers()

--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -16,6 +16,5 @@ export const SUPPORTED_LANGUAGES = [
 
 export const SUPPORTED_CURRENCIES = [
   "usd",
-  "btc",
   "rub"
 ] as const

--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -12,10 +12,10 @@ export const PBKDF2_TARGET_MS = 200
 
 export const SUPPORTED_LANGUAGES = [
   "en",
-]
+] as const
 
 export const SUPPORTED_CURRENCIES = [
   "usd",
   "btc",
   "rub"
-]
+] as const

--- a/src/main/src/preferences/general.ts
+++ b/src/main/src/preferences/general.ts
@@ -11,13 +11,15 @@ export const GeneralPreferencesSchema = z.object({
 })
 
 export type GeneralPreferencesJSON = z.infer<typeof GeneralPreferencesSchema>
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number]
+export type SupportedCurrency = typeof SUPPORTED_CURRENCIES[number]
 
 export class GeneralPreferences {
-  language: string
-  currency: string
+  language: SupportedLanguage
+  currency: SupportedCurrency
   connectionType: ConnectionType
 
-  constructor(language: string, currency: string, connectionType: ConnectionType) {
+  constructor(language: SupportedLanguage, currency: SupportedCurrency, connectionType: ConnectionType) {
     this.language = language
     this.currency = currency
     this.connectionType = connectionType

--- a/src/main/src/services/RatesService.ts
+++ b/src/main/src/services/RatesService.ts
@@ -23,15 +23,50 @@ export class CoinGeckoRateProvider implements RateProvider {
 
   async fetchRates(): Promise<Rates> {
     const response = await net.fetch(this.url)
+
     if (!response.ok) {
       throw new Error(`CoinGecko HTTP ${response.status}`)
     }
+
     const data = await response.json() as {dash?: Partial<Record<string, number>>}
     const rates: Rates = {}
+
     for (const c of SUPPORTED_CURRENCIES) {
       const v = data.dash?.[c]
       if (typeof v === 'number') rates[c] = v
     }
+
+    return rates
+  }
+}
+
+// Fallback provider. CryptoCompare uses uppercase ticker symbols and may
+// return 200 OK with {Response: "Error", ...} on failure, so we have to
+// detect that explicitly.
+export class CryptoCompareRateProvider implements RateProvider {
+  readonly name = 'cryptocompare'
+  private readonly url = `https://min-api.cryptocompare.com/data/price?fsym=DASH&tsyms=${SUPPORTED_CURRENCIES.map(c => c.toUpperCase()).join(',')}`
+
+  async fetchRates(): Promise<Rates> {
+    const response = await net.fetch(this.url)
+
+    if (!response.ok) {
+      throw new Error(`CryptoCompare HTTP ${response.status}`)
+    }
+
+    const data = await response.json() as Partial<Record<string, number>> & {Response?: string, Message?: string}
+
+    if (data.Response === 'Error') {
+      throw new Error(`CryptoCompare: ${data.Message ?? 'unknown error'}`)
+    }
+
+    const rates: Rates = {}
+
+    for (const c of SUPPORTED_CURRENCIES) {
+      const v = data[c.toUpperCase()]
+      if (typeof v === 'number') rates[c] = v
+    }
+
     return rates
   }
 }
@@ -48,7 +83,7 @@ export class RatesService {
   constructor(providers?: RateProvider[], ttlMs: number = DEFAULT_TTL_MS) {
     this.providers = providers != null && providers.length > 0
       ? providers
-      : [new CoinGeckoRateProvider()]
+      : [new CoinGeckoRateProvider(), new CryptoCompareRateProvider()]
     this.ttlMs = ttlMs
   }
 

--- a/src/main/src/services/RatesService.ts
+++ b/src/main/src/services/RatesService.ts
@@ -54,37 +54,54 @@ export class RatesService {
 
   async getRate(currency: FiatCurrency): Promise<number> {
     const rate = (await this.getRates())[currency]
+
     if (rate == null) {
       throw new Error(`Rate for ${currency} unavailable`)
     }
+
     return rate
   }
 
   async getRates(): Promise<Rates> {
-    const cached = this.cache
-    if (cached != null && Date.now() - cached.fetchedAt < this.ttlMs) {
-      return cached.rates
+    // Fresh cache — serve immediately, without hitting the network.
+    if (this.cache != null && this.isFresh(this.cache)) {
+      return this.cache.rates
     }
+
+    // Stale cache — refresh (parallel callers collapse onto a single request).
     return (await this.refresh()).rates
   }
 
-  private async refresh(): Promise<RateCache> {
-    if (this.inflight != null) return this.inflight
-    this.inflight = this.fetchFromProviders().finally(() => {
-      this.inflight = null
-    })
+  private isFresh(cache: RateCache): boolean {
+    return Date.now() - cache.fetchedAt < this.ttlMs
+  }
+
+  private refresh(): Promise<RateCache> {
+    // Single-flight: if a refresh is already running, join it instead of
+    // firing a second network request.
+    if (this.inflight != null) {
+      return this.inflight
+    }
+
+    this.inflight = this.fetchFromProviders()
+    this.inflight.finally(() => { this.inflight = null })
+
     return this.inflight
   }
 
   private async fetchFromProviders(): Promise<RateCache> {
     const errors: string[] = []
+
+    // Try providers in order, take the first one with a non-empty response.
     for (const provider of this.providers) {
       try {
         const rates = await provider.fetchRates()
+
         if (Object.keys(rates).length === 0) {
           errors.push(`${provider.name}: empty rates`)
           continue
         }
+
         this.cache = {rates, fetchedAt: Date.now()}
         return this.cache
       } catch (err) {
@@ -92,6 +109,8 @@ export class RatesService {
         errors.push(`${provider.name}: ${msg}`)
       }
     }
+
+    // Reached only when every provider failed or returned empty rates.
     throw new Error(`All rate providers failed: ${errors.join('; ')}`)
   }
 }

--- a/src/main/src/services/RatesService.ts
+++ b/src/main/src/services/RatesService.ts
@@ -1,61 +1,97 @@
 import {net} from 'electron'
+import {SUPPORTED_CURRENCIES} from '../constants'
 
-export type FiatCurrency = 'usd' | 'btc' | 'rub'
+export type FiatCurrency = typeof SUPPORTED_CURRENCIES[number]
+
+export type Rates = Partial<Record<FiatCurrency, number>>
+
+export interface RateProvider {
+  readonly name: string
+  fetchRates(): Promise<Rates>
+}
 
 interface RateCache {
-  rates: Record<FiatCurrency, number>
+  rates: Rates
   fetchedAt: number
 }
 
 const DEFAULT_TTL_MS = 60_000
-const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=dash&vs_currencies=usd,btc,rub'
 
-// CoinGecko returns all 3 currencies in one call — cached together under a
-// single fetchedAt timestamp. `inflight` deduplicates concurrent refreshes
-// (e.g. getWalletBalance + getAddresses firing in parallel after cache miss).
+export class CoinGeckoRateProvider implements RateProvider {
+  readonly name = 'coingecko'
+  private readonly url = `https://api.coingecko.com/api/v3/simple/price?ids=dash&vs_currencies=${SUPPORTED_CURRENCIES.join(',')}`
+
+  async fetchRates(): Promise<Rates> {
+    const response = await net.fetch(this.url)
+    if (!response.ok) {
+      throw new Error(`CoinGecko HTTP ${response.status}`)
+    }
+    const data = await response.json() as {dash?: Partial<Record<string, number>>}
+    const rates: Rates = {}
+    for (const c of SUPPORTED_CURRENCIES) {
+      const v = data.dash?.[c]
+      if (typeof v === 'number') rates[c] = v
+    }
+    return rates
+  }
+}
+
+// Multi-provider fallback: tries providers in order, returns first non-empty
+// response. `inflight` deduplicates concurrent refreshes (e.g. getWalletBalance
+// + getAddresses firing in parallel after cache miss).
 export class RatesService {
   private cache: RateCache | null = null
   private inflight: Promise<RateCache> | null = null
+  private readonly providers: RateProvider[]
   private readonly ttlMs: number
 
-  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+  constructor(providers?: RateProvider[], ttlMs: number = DEFAULT_TTL_MS) {
+    this.providers = providers != null && providers.length > 0
+      ? providers
+      : [new CoinGeckoRateProvider()]
     this.ttlMs = ttlMs
   }
 
   async getRate(currency: FiatCurrency): Promise<number> {
-    return (await this.getRates())[currency]
+    const rate = (await this.getRates())[currency]
+    if (rate == null) {
+      throw new Error(`Rate for ${currency} unavailable`)
+    }
+    return rate
   }
 
-  async getRates(): Promise<Record<FiatCurrency, number>> {
+  async getRates(): Promise<Rates> {
     const cached = this.cache
-    if (cached && Date.now() - cached.fetchedAt < this.ttlMs) {
+    if (cached != null && Date.now() - cached.fetchedAt < this.ttlMs) {
       return cached.rates
     }
     return (await this.refresh()).rates
   }
 
   private async refresh(): Promise<RateCache> {
-    if (this.inflight) return this.inflight
-    this.inflight = this.fetchRates().finally(() => {
+    if (this.inflight != null) return this.inflight
+    this.inflight = this.fetchFromProviders().finally(() => {
       this.inflight = null
     })
     return this.inflight
   }
 
-  private async fetchRates(): Promise<RateCache> {
-    const response = await net.fetch(COINGECKO_URL)
-    if (!response.ok) {
-      throw new Error(`CoinGecko HTTP ${response.status}`)
+  private async fetchFromProviders(): Promise<RateCache> {
+    const errors: string[] = []
+    for (const provider of this.providers) {
+      try {
+        const rates = await provider.fetchRates()
+        if (Object.keys(rates).length === 0) {
+          errors.push(`${provider.name}: empty rates`)
+          continue
+        }
+        this.cache = {rates, fetchedAt: Date.now()}
+        return this.cache
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err)
+        errors.push(`${provider.name}: ${msg}`)
+      }
     }
-    const data = await response.json() as {dash?: Partial<Record<FiatCurrency, number>>}
-    const {usd, btc, rub} = data.dash ?? {}
-    if (usd == null || btc == null || rub == null) {
-      throw new Error('CoinGecko response missing dash rates')
-    }
-    this.cache = {
-      rates: {usd, btc, rub},
-      fetchedAt: Date.now(),
-    }
-    return this.cache
+    throw new Error(`All rate providers failed: ${errors.join('; ')}`)
   }
 }

--- a/src/main/src/services/RatesService.ts
+++ b/src/main/src/services/RatesService.ts
@@ -1,0 +1,61 @@
+import {net} from 'electron'
+
+export type FiatCurrency = 'usd' | 'btc' | 'rub'
+
+interface RateCache {
+  rates: Record<FiatCurrency, number>
+  fetchedAt: number
+}
+
+const DEFAULT_TTL_MS = 60_000
+const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price?ids=dash&vs_currencies=usd,btc,rub'
+
+// CoinGecko returns all 3 currencies in one call — cached together under a
+// single fetchedAt timestamp. `inflight` deduplicates concurrent refreshes
+// (e.g. getWalletBalance + getAddresses firing in parallel after cache miss).
+export class RatesService {
+  private cache: RateCache | null = null
+  private inflight: Promise<RateCache> | null = null
+  private readonly ttlMs: number
+
+  constructor(ttlMs: number = DEFAULT_TTL_MS) {
+    this.ttlMs = ttlMs
+  }
+
+  async getRate(currency: FiatCurrency): Promise<number> {
+    return (await this.getRates())[currency]
+  }
+
+  async getRates(): Promise<Record<FiatCurrency, number>> {
+    const cached = this.cache
+    if (cached && Date.now() - cached.fetchedAt < this.ttlMs) {
+      return cached.rates
+    }
+    return (await this.refresh()).rates
+  }
+
+  private async refresh(): Promise<RateCache> {
+    if (this.inflight) return this.inflight
+    this.inflight = this.fetchRates().finally(() => {
+      this.inflight = null
+    })
+    return this.inflight
+  }
+
+  private async fetchRates(): Promise<RateCache> {
+    const response = await net.fetch(COINGECKO_URL)
+    if (!response.ok) {
+      throw new Error(`CoinGecko HTTP ${response.status}`)
+    }
+    const data = await response.json() as {dash?: Partial<Record<FiatCurrency, number>>}
+    const {usd, btc, rub} = data.dash ?? {}
+    if (usd == null || btc == null || rub == null) {
+      throw new Error('CoinGecko response missing dash rates')
+    }
+    this.cache = {
+      rates: {usd, btc, rub},
+      fetchedAt: Date.now(),
+    }
+    return this.cache
+  }
+}

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -5,7 +5,7 @@ import {AddressDAO} from '../database/AddressDAO'
 import {IdentityDAO} from '../database/IdentityDAO'
 import {TransactionDAO} from '../database/TransactionDAO'
 import {ApplicationService} from './ApplicationService'
-import {RatesService} from './RatesService'
+import {RatesService, FiatCurrency} from './RatesService'
 import {WalletProvider} from '../providers/WalletProvider'
 import {InsightWalletProvider} from '../providers/InsightWalletProvider'
 import {P2PWalletProvider} from '../providers/P2PWalletProvider'
@@ -89,28 +89,34 @@ export class WalletService {
     this.sdk = sdk
   }
 
-  // DASH satoshis (1 satoshi = 1 duff = 1e-8 DASH) → USD string with 2
+  // DASH satoshis (1 satoshi = 1 duff = 1e-8 DASH) → fiat string with 2
   // decimals. Returns '0.0' if rate fetch fails so balance display never
   // breaks on network blips.
-  private async satoshisToUsd(satoshis: bigint): Promise<string> {
+  private async satoshisToFiat(satoshis: bigint, currency: FiatCurrency): Promise<string> {
     try {
-      const rate = await this.ratesService.getRate('usd')
+      const rate = await this.ratesService.getRate(currency)
       return (Number(satoshis) / 1e8 * rate).toFixed(2)
     } catch (err) {
-      console.warn('[rates] failed to fetch DASH/USD rate:', err)
+      console.warn(`[rates] failed to fetch DASH/${currency.toUpperCase()} rate:`, err)
       return '0.0'
     }
   }
 
   // Platform credits: 1 duff = 1000 credits, so 1 credit = 1e-11 DASH.
-  private async creditsToUsd(credits: bigint): Promise<string> {
+  private async creditsToFiat(credits: bigint, currency: FiatCurrency): Promise<string> {
     try {
-      const rate = await this.ratesService.getRate('usd')
+      const rate = await this.ratesService.getRate(currency)
       return (Number(credits) / 1e11 * rate).toFixed(2)
     } catch (err) {
-      console.warn('[rates] failed to fetch DASH/USD rate:', err)
+      console.warn(`[rates] failed to fetch DASH/${currency.toUpperCase()} rate:`, err)
       return '0.0'
     }
+  }
+
+  // User's selected fiat currency from preferences — single source of truth
+  // for which fiat to convert DASH balances into.
+  private get fiatCurrency(): FiatCurrency {
+    return this.applicationService.preferences.general.currency
   }
 
   private getProvider(walletId: string, network: Network): WalletProvider {
@@ -296,7 +302,7 @@ export class WalletService {
       return {
         ...address,
         balance,
-        usdBalance: await this.satoshisToUsd(balance),
+        usdBalance: await this.satoshisToFiat(balance, this.fiatCurrency),
       }
     }))
 
@@ -305,7 +311,7 @@ export class WalletService {
       return {
         ...address,
         balance,
-        usdBalance: await this.satoshisToUsd(balance),
+        usdBalance: await this.satoshisToFiat(balance, this.fiatCurrency),
       }
     }))
 
@@ -385,11 +391,11 @@ export class WalletService {
     return {
       dash: {
         amount: addressesBalance,
-        usdAmount: await this.satoshisToUsd(addressesBalance),
+        usdAmount: await this.satoshisToFiat(addressesBalance, this.fiatCurrency),
       },
       credits: {
         amount: identitiesBalance,
-        usdAmount: await this.creditsToUsd(identitiesBalance),
+        usdAmount: await this.creditsToFiat(identitiesBalance, this.fiatCurrency),
       }
     }
   }
@@ -439,7 +445,7 @@ export class WalletService {
           alias,
           balance: {
             amount: balance,
-            usdAmount: await this.creditsToUsd(balance),
+            usdAmount: await this.creditsToFiat(balance, this.fiatCurrency),
           },
           derivationPath: entry.derivationPath
         })

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -5,6 +5,7 @@ import {AddressDAO} from '../database/AddressDAO'
 import {IdentityDAO} from '../database/IdentityDAO'
 import {TransactionDAO} from '../database/TransactionDAO'
 import {ApplicationService} from './ApplicationService'
+import {RatesService} from './RatesService'
 import {WalletProvider} from '../providers/WalletProvider'
 import {InsightWalletProvider} from '../providers/InsightWalletProvider'
 import {P2PWalletProvider} from '../providers/P2PWalletProvider'
@@ -64,6 +65,7 @@ export class WalletService {
   private identityDAO: IdentityDAO
   private transactionDAO: TransactionDAO
   private applicationService: ApplicationService
+  private ratesService: RatesService
   private sdk: DashPlatformSDK
   private pbkdf2Iterations: number
 
@@ -73,6 +75,7 @@ export class WalletService {
     identityDAO: IdentityDAO,
     transactionDAO: TransactionDAO,
     applicationService: ApplicationService,
+    ratesService: RatesService,
     sdk: DashPlatformSDK,
     pbkdf2Iterations: number,
   ) {
@@ -82,7 +85,32 @@ export class WalletService {
     this.identityDAO = identityDAO
     this.transactionDAO = transactionDAO
     this.applicationService = applicationService
+    this.ratesService = ratesService
     this.sdk = sdk
+  }
+
+  // DASH satoshis (1 satoshi = 1 duff = 1e-8 DASH) → USD string with 2
+  // decimals. Returns '0.0' if rate fetch fails so balance display never
+  // breaks on network blips.
+  private async satoshisToUsd(satoshis: bigint): Promise<string> {
+    try {
+      const rate = await this.ratesService.getRate('usd')
+      return (Number(satoshis) / 1e8 * rate).toFixed(2)
+    } catch (err) {
+      console.warn('[rates] failed to fetch DASH/USD rate:', err)
+      return '0.0'
+    }
+  }
+
+  // Platform credits: 1 duff = 1000 credits, so 1 credit = 1e-11 DASH.
+  private async creditsToUsd(credits: bigint): Promise<string> {
+    try {
+      const rate = await this.ratesService.getRate('usd')
+      return (Number(credits) / 1e11 * rate).toFixed(2)
+    } catch (err) {
+      console.warn('[rates] failed to fetch DASH/USD rate:', err)
+      return '0.0'
+    }
   }
 
   private getProvider(walletId: string, network: Network): WalletProvider {
@@ -263,20 +291,23 @@ export class WalletService {
 
     const provider = this.getProvider(wallet.walletId, wallet.network)
 
-    // TODO: add real usd balance
-    const receivingAddressesWithBalance = await Promise.all(addresses.receiving.map(async (address) => ({
+    const receivingAddressesWithBalance = await Promise.all(addresses.receiving.map(async (address) => {
+      const balance = await provider.getBalance(address.address)
+      return {
         ...address,
-        balance: await provider.getBalance(address.address),
-        usdBalance: '0.0'
-      })
-    ))
+        balance,
+        usdBalance: await this.satoshisToUsd(balance),
+      }
+    }))
 
-    const changeAddressesWithBalance = await Promise.all(addresses.change.map(async (address) => ({
+    const changeAddressesWithBalance = await Promise.all(addresses.change.map(async (address) => {
+      const balance = await provider.getBalance(address.address)
+      return {
         ...address,
-        balance: await provider.getBalance(address.address),
-        usdBalance: '0.0'
-      })
-    ))
+        balance,
+        usdBalance: await this.satoshisToUsd(balance),
+      }
+    }))
 
     return {
       receiving: receivingAddressesWithBalance,
@@ -354,11 +385,11 @@ export class WalletService {
     return {
       dash: {
         amount: addressesBalance,
-        usdAmount: '0.0'
+        usdAmount: await this.satoshisToUsd(addressesBalance),
       },
       credits: {
         amount: identitiesBalance,
-        usdAmount: '0.0'
+        usdAmount: await this.creditsToUsd(identitiesBalance),
       }
     }
   }
@@ -401,14 +432,14 @@ export class WalletService {
           alias = `${label}.${parentDomainName}`
         }
 
-        // TODO: Implement read usd amount
+        const balance = BigInt(identity.balance)
         results.push({
           identityIndex: entry.identityIndex,
           identifier: identity.id.base58(),
           alias,
           balance: {
-            amount: BigInt(identity.balance),
-            usdAmount: '0.0'
+            amount: balance,
+            usdAmount: await this.creditsToUsd(balance),
           },
           derivationPath: entry.derivationPath
         })


### PR DESCRIPTION
## Issue
Every `usdAmount` / `usdBalance` field returned by the backend was hardcoded `'0.0'` with `// TODO: add real usd balance` comments — `getWalletBalance` (both DASH and credits), `getIdentities` (per identity balance), and `getAddressesByWalletId` (per-address balance). The renderer had no real fiat value to display anywhere.

## Done
- New `services/RatesService.ts` — in-memory cache with configurable TTL (default 60s, override via constructor). One CoinGecko call (`/simple/price?ids=dash&vs_currencies=usd,btc,rub`) populates all three currencies under a single timestamp. Concurrent cache-miss callers share a single HTTP request via an `inflight` promise — saves a thundering herd on first paint.
- `RatesService.getRate(currency)` / `getRates()` are polymorphic over `'usd' | 'btc' | 'rub'`. The service is already multi-currency even though only USD is consumed for now (preserves the existing `usdAmount` field name).
- `WalletService` constructor accepts a `ratesService`. Two private helpers:
  - `satoshisToUsd(satoshis)` — 1 satoshi = 1 duff = 1e-8 DASH.
  - `creditsToUsd(credits)` — Platform fixed conversion 1 duff = 1000 credits → 1 credit = 1e-11 DASH.
- Filled `usdAmount` / `usdBalance` in `getWalletBalance` (DASH + credits), `getIdentities`, and both address sets in `getAddressesByWalletId`.
- Fail-safe: any rate-fetch error is caught inside the helpers — warning logged, `'0.0'` returned — so a CoinGecko outage never breaks the balance UI.
- `WalletBackend` instantiates `new RatesService()` and injects it into `WalletService`. No IPC channel yet — service is consumed internally only.
