### PR TITLE
fix(p2p): sync stability and cfilter fixes

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -91,3 +91,16 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+
+// Stop the p2p utility process gracefully before quitting so chain.db's
+// LevelDB lock is released. Without this a killed worker leaves a stale lock
+// that blocks the next launch's open (LEVEL_DATABASE_NOT_OPEN).
+let backendStopped = false
+app.on('before-quit', (event) => {
+  if (backendStopped) return
+  event.preventDefault()
+  backendStopped = true
+  backend.shutdown()
+    .catch((err) => console.error('[shutdown] backend shutdown failed:', err))
+    .finally(() => app.quit())
+})

--- a/src/main/p2p/SyncService.ts
+++ b/src/main/p2p/SyncService.ts
@@ -1,5 +1,5 @@
 import {BroadcastService} from './BroadcastService'
-import {ChainStore, PersistedHeader} from './ChainStore'
+import {ChainStore, ChainTipState, PersistedHeader} from './ChainStore'
 import {GENESIS} from './constants'
 import {PoolService} from './PoolService'
 import {
@@ -83,7 +83,26 @@ export class SyncService {
 
   getStatus = (): WalletSyncStatus => this.status
 
-  start = async (cmd: P2PStartMessage): Promise<void> => {
+  // Serialize lifecycle ops so two near-simultaneous start commands can't both
+  // open chain.db — LevelDB is single-owner and a second concurrent open fails
+  // the lock (surfacing as LEVEL_DATABASE_NOT_OPEN).
+  private opChain: Promise<unknown> = Promise.resolve()
+
+  private runExclusive = <T>(fn: () => Promise<T>): Promise<T> => {
+    const run = this.opChain.then(fn, fn)
+    this.opChain = run.then(() => undefined, () => undefined)
+    return run
+  }
+
+  start = (cmd: P2PStartMessage): Promise<void> => this.runExclusive(() => this.startInner(cmd))
+
+  stop = (): Promise<void> => this.runExclusive(() => this.stopInner())
+
+  private startInner = async (cmd: P2PStartMessage): Promise<void> => {
+    // Already syncing this wallet — a duplicate start (StrictMode double-invoke,
+    // overlapping auto-start). Ignore rather than tear down and re-open chain.db.
+    if (this.chainStore && this.activeWalletId === cmd.walletId) return
+
     await this.teardown()
 
     this.activeWalletId = cmd.walletId
@@ -114,14 +133,12 @@ export class SyncService {
     // Open chain.db (single-owner LevelDB lock). Chain.db now holds only
     // network-scoped data (headers, hash cache, filter headers).
     this.chainStore = new ChainStore(cmd.chainDbPath, cmd.network)
-    let persisted
+    let persisted: ChainTipState
     try {
-      await this.chainStore.open()
-      persisted = await this.chainStore.initSyncState()
+      persisted = await this.openWithRetry(this.chainStore)
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err)
       const code = (err as { code?: string }).code ?? 'unknown'
-      const labelled = `chain.db unusable (${code}): ${message}. Call resetWalletSync to recover.`
+      const labelled = `chain.db unusable (${code}): ${describeError(err)}. Call resetWalletSync to recover.`
       await this.chainStore.close().catch(() => { /* ignore */ })
       this.chainStore = null
       this.emit({phase: 'stopped', lastError: labelled})
@@ -169,7 +186,7 @@ export class SyncService {
     this.headerSyncWorker.start()
   }
 
-  stop = async (): Promise<void> => {
+  private stopInner = async (): Promise<void> => {
     await this.teardown()
     this.activeWalletId = null
     this.activeWatchAddresses = []
@@ -190,6 +207,29 @@ export class SyncService {
       filterCapablePeerCount: 0,
       phaseEtaMs: null,
     })
+  }
+
+  // Open chain.db, retrying a few times on failure. The common transient is a
+  // still-held LevelDB lock (a prior session's utility process releasing it);
+  // a short backoff recovers automatically instead of forcing a resetWalletSync.
+  private async openWithRetry(store: ChainStore): Promise<ChainTipState> {
+    const ATTEMPTS = 5
+    const BACKOFF_MS = 400
+    let lastErr: unknown
+    for (let attempt = 1; attempt <= ATTEMPTS; attempt++) {
+      try {
+        await store.open()
+        return await store.initSyncState()
+      } catch (err) {
+        lastErr = err
+        await store.close().catch(() => { /* ignore */ })
+        if (attempt < ATTEMPTS) {
+          console.warn(`[p2p] chain.db open attempt ${attempt}/${ATTEMPTS} failed, retrying: ${describeError(err)}`)
+          await delay(BACKOFF_MS)
+        }
+      }
+    }
+    throw lastErr
   }
 
   broadcast = (cmd: P2PBroadcastMessage): void => {
@@ -410,6 +450,20 @@ export class SyncService {
         .finally(() => this.emit({phase: 'stopped'}))
     }
   }
+}
+
+// abstract-level wraps a failed open as LEVEL_DATABASE_NOT_OPEN ("Database
+// failed to open") and hides the real reason (held lock, IO error) in `cause`.
+// Surface it so logs name the actual problem instead of the generic wrapper.
+function describeError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err)
+  const cause = (err as { cause?: unknown })?.cause
+  const causeMsg = cause instanceof Error ? cause.message : cause != null ? String(cause) : null
+  return causeMsg ? `${message} (cause: ${causeMsg})` : message
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 // Reverse a hex string byte-wise (wire/internal txid order ⇄ display order).

--- a/src/main/p2p/constants.ts
+++ b/src/main/p2p/constants.ts
@@ -1,27 +1,17 @@
 import {Network} from '../src/types'
 
-// Chain anchor: the block our index starts from.
-//   - height:     internal height we seed it at (always 1; our index is 1-based)
-//   - wireHeight: that same block's real height in Dash Core's numbering, used
-//                 for BIP157 start_height fields. mainnet's anchor is the true
-//                 genesis (real height 0); testnet's anchor is block 1 (real
-//                 height 1). The internal↔real offset (wireHeight - 1) differs
-//                 per network, so cf* requests must convert per network.
 export interface ChainAnchor {
   height: number
-  wireHeight: number
   hash: string
 }
 
 export const GENESIS: Record<Network, ChainAnchor> = {
   mainnet: {
     height: 1,
-    wireHeight: 0,
-    hash: '00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6',
+    hash: '000007d91d1254d60e2dd1ae580383070a4ddffa4c64c2eeb4a2f9ecc0414343',
   },
   testnet: {
     height: 1,
-    wireHeight: 1,
     hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
   },
 }

--- a/src/main/p2p/constants.ts
+++ b/src/main/p2p/constants.ts
@@ -1,18 +1,27 @@
 import {Network} from '../src/types'
 
-// position of that block in Dash Core's height numbering.
+// Chain anchor: the block our index starts from.
+//   - height:     internal height we seed it at (always 1; our index is 1-based)
+//   - wireHeight: that same block's real height in Dash Core's numbering, used
+//                 for BIP157 start_height fields. mainnet's anchor is the true
+//                 genesis (real height 0); testnet's anchor is block 1 (real
+//                 height 1). The internal↔real offset (wireHeight - 1) differs
+//                 per network, so cf* requests must convert per network.
 export interface ChainAnchor {
   height: number
+  wireHeight: number
   hash: string
 }
 
 export const GENESIS: Record<Network, ChainAnchor> = {
   mainnet: {
     height: 1,
+    wireHeight: 0,
     hash: '00000ffd590b1485b3caadc19b22e6379c733355108f107a430458cdf3407ab6',
   },
   testnet: {
     height: 1,
+    wireHeight: 1,
     hash: '0000047d24635e347be3aaaeb66c26be94901a2f962feccd4f95090191f208c1',
   },
 }

--- a/src/main/p2p/workers/CFilterSyncWorker.ts
+++ b/src/main/p2p/workers/CFilterSyncWorker.ts
@@ -121,9 +121,6 @@ export class CFilterSyncWorker extends Worker {
 
   // ── deps + immutable seed ────────────────────────────────────────────────
   private readonly network: Network
-  // real - internal: maps our 1-based index height to Dash Core's height for
-  // BIP157 wire fields. Per network (the anchor sits at a different real height).
-  private readonly heightOffset: number
   private readonly walletId: string
   private readonly chainStore: ChainStore
   private readonly peerPool: PoolService
@@ -208,7 +205,6 @@ export class CFilterSyncWorker extends Worker {
   constructor(opts: CFilterSyncWorkerOptions) {
     super()
     this.network = opts.network
-    this.heightOffset = GENESIS[opts.network].wireHeight - 1
     this.walletId = opts.walletId
     this.chainStore = opts.chainStore
     this.peerPool = opts.peerPool
@@ -351,16 +347,6 @@ export class CFilterSyncWorker extends Worker {
     return Math.max(this.birthdayHeight, this.chainTipHeight - SCAN_TIP_DEPTH)
   }
 
-  // Internal (1-based) height ⇄ Dash Core (wire) height. Used wherever a height
-  // crosses to/from peers: BIP157 start_height fields and cfcheckpt boundaries.
-  private toReal(internalHeight: number): number {
-    return internalHeight + this.heightOffset
-  }
-
-  private toInternal(realHeight: number): number {
-    return realHeight - this.heightOffset
-  }
-
   // ── chain index ───────────────────────────────────────────────────────────
 
   private async buildChainIndex(): Promise<void> {
@@ -470,8 +456,7 @@ export class CFilterSyncWorker extends Worker {
     this.cfcheckpt.responded = false
     // Highest checkpoint (real height that is a multiple of 1000) at or below
     // the scan tip, expressed in our internal numbering.
-    const ckptReal = Math.floor(this.toReal(this.effectiveScanTipHeight()) / 1000) * 1000
-    const stopHeight = this.toInternal(ckptReal)
+    const stopHeight = Math.floor(this.effectiveScanTipHeight() / 1000) * 1000
     const stopHashWire = this.heightToBlockHash.get(stopHeight)
     if (!stopHashWire) {
       console.warn(`[cfilter] cfcheckpt: no hash for stop h=${stopHeight}, chain too short`)
@@ -516,7 +501,7 @@ export class CFilterSyncWorker extends Worker {
     // headers[i] is the filter header at real height (i+1)*1000; key it by the
     // matching internal height.
     for (let i = 0; i < headers.length; i++) {
-      this.checkpointHeaders.set(this.toInternal((i + 1) * 1000), headers[i]!)
+      this.checkpointHeaders.set((i + 1) * 1000, headers[i]!)
     }
 
     // Cross-validate cached filter headers against checkpoints.
@@ -539,9 +524,8 @@ export class CFilterSyncWorker extends Worker {
     }
 
     const start = Math.max(this.birthdayHeight, this.cfilter.cursor)
-    const anchorReal = Math.floor((this.toReal(start) - 1) / 1000) * 1000
-    const anchorCkpt = this.toInternal(anchorReal)
-    if (anchorReal > 0 && this.checkpointHeaders.has(anchorCkpt)) {
+    const anchorCkpt = Math.floor((start - 1) / 1000) * 1000
+    if (anchorCkpt > 0 && this.checkpointHeaders.has(anchorCkpt)) {
       this.anchorHeight = anchorCkpt
       this.heightToFilterHeader.set(anchorCkpt, this.checkpointHeaders.get(anchorCkpt)!)
     } else {
@@ -560,7 +544,7 @@ export class CFilterSyncWorker extends Worker {
 
     while (this.cfHeaders.walkStart <= effectiveTip) {
       const startHeight = this.cfHeaders.walkStart
-      const nextCkpt = this.toInternal((Math.floor(this.toReal(startHeight) / 1000) + 1) * 1000)
+      const nextCkpt = (Math.floor(startHeight / 1000) + 1) * 1000
       const stopHeight = Math.min(nextCkpt, effectiveTip)
       let fullyCached = true
       for (let h = startHeight; h <= stopHeight; h++) {
@@ -577,7 +561,7 @@ export class CFilterSyncWorker extends Worker {
     }
     this.emitStatus('cfheaders')
     const startHeight = this.cfHeaders.walkStart
-    const nextCkpt = this.toInternal((Math.floor(this.toReal(startHeight) / 1000) + 1) * 1000)
+    const nextCkpt = (Math.floor(startHeight / 1000) + 1) * 1000
     const stopHeight = Math.min(nextCkpt, effectiveTip)
     if (!this.heightToBlockHash.has(stopHeight)) {
       console.warn(`[cfilter] cfheaders: no hash for h=${stopHeight}; stopping`)
@@ -603,7 +587,7 @@ export class CFilterSyncWorker extends Worker {
       candidates = [...this.peerPool.filterCapablePeers]
     }
     const picks = candidates.slice(0, CFHEADERS_RACE_PEERS)
-    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: this.toReal(entry.startHeight), stopHash: stopHashWire})
+    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: entry.startHeight, stopHash: stopHashWire})
     for (const p of picks) {
       entry.triedPeers.add(p)
       p.sendMessage(msg)
@@ -692,7 +676,7 @@ export class CFilterSyncWorker extends Worker {
     if (racers.length === 0) return
     const msg = this.M.GetCFilters({
       filterType: FILTER_TYPE,
-      startHeight: this.toReal(batch.startHeight),
+      startHeight: batch.startHeight,
       stopHash: batch.stopHashWire,
     })
     for (const p of racers) p.sendMessage(msg)

--- a/src/main/p2p/workers/CFilterSyncWorker.ts
+++ b/src/main/p2p/workers/CFilterSyncWorker.ts
@@ -116,19 +116,14 @@ function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
   return true
 }
 
-// Chain heights here are 1-based (genesis = height 1, see GENESIS), but the
-// BIP157 start_height field is Dash Core's 0-based height. Convert when a
-// height crosses to the wire; the matching stop hash already resolves to the
-// peer's height, so only the numeric field needs shifting.
-function toWireHeight(internalHeight: number): number {
-  return internalHeight - 1
-}
-
 export class CFilterSyncWorker extends Worker {
   readonly name = 'CFilterSyncWorker'
 
   // ── deps + immutable seed ────────────────────────────────────────────────
   private readonly network: Network
+  // real - internal: maps our 1-based index height to Dash Core's height for
+  // BIP157 wire fields. Per network (the anchor sits at a different real height).
+  private readonly heightOffset: number
   private readonly walletId: string
   private readonly chainStore: ChainStore
   private readonly peerPool: PoolService
@@ -213,6 +208,7 @@ export class CFilterSyncWorker extends Worker {
   constructor(opts: CFilterSyncWorkerOptions) {
     super()
     this.network = opts.network
+    this.heightOffset = GENESIS[opts.network].wireHeight - 1
     this.walletId = opts.walletId
     this.chainStore = opts.chainStore
     this.peerPool = opts.peerPool
@@ -355,6 +351,16 @@ export class CFilterSyncWorker extends Worker {
     return Math.max(this.birthdayHeight, this.chainTipHeight - SCAN_TIP_DEPTH)
   }
 
+  // Internal (1-based) height ⇄ Dash Core (wire) height. Used wherever a height
+  // crosses to/from peers: BIP157 start_height fields and cfcheckpt boundaries.
+  private toReal(internalHeight: number): number {
+    return internalHeight + this.heightOffset
+  }
+
+  private toInternal(realHeight: number): number {
+    return realHeight - this.heightOffset
+  }
+
   // ── chain index ───────────────────────────────────────────────────────────
 
   private async buildChainIndex(): Promise<void> {
@@ -462,9 +468,10 @@ export class CFilterSyncWorker extends Worker {
   private requestCheckpoints(): void {
     if (this.stopped) return
     this.cfcheckpt.responded = false
-    // Checkpoints land on real heights that are multiples of 1000; in our
-    // 1-based numbering those are internal heights k*1000+1.
-    const stopHeight = Math.floor((this.effectiveScanTipHeight() - 1) / 1000) * 1000 + 1
+    // Highest checkpoint (real height that is a multiple of 1000) at or below
+    // the scan tip, expressed in our internal numbering.
+    const ckptReal = Math.floor(this.toReal(this.effectiveScanTipHeight()) / 1000) * 1000
+    const stopHeight = this.toInternal(ckptReal)
     const stopHashWire = this.heightToBlockHash.get(stopHeight)
     if (!stopHashWire) {
       console.warn(`[cfilter] cfcheckpt: no hash for stop h=${stopHeight}, chain too short`)
@@ -506,10 +513,10 @@ export class CFilterSyncWorker extends Worker {
     this.leader = fromPeer
 
     const headers = msg.filterHeaders ?? []
-    // headers[i] is the filter header at real height (i+1)*1000; store it under
-    // the matching internal height (one higher in our 1-based numbering).
+    // headers[i] is the filter header at real height (i+1)*1000; key it by the
+    // matching internal height.
     for (let i = 0; i < headers.length; i++) {
-      this.checkpointHeaders.set((i + 1) * 1000 + 1, headers[i]!)
+      this.checkpointHeaders.set(this.toInternal((i + 1) * 1000), headers[i]!)
     }
 
     // Cross-validate cached filter headers against checkpoints.
@@ -532,8 +539,9 @@ export class CFilterSyncWorker extends Worker {
     }
 
     const start = Math.max(this.birthdayHeight, this.cfilter.cursor)
-    const anchorCkpt = Math.floor((start - 1) / 1000) * 1000 + 1
-    if (anchorCkpt > 1 && this.checkpointHeaders.has(anchorCkpt)) {
+    const anchorReal = Math.floor((this.toReal(start) - 1) / 1000) * 1000
+    const anchorCkpt = this.toInternal(anchorReal)
+    if (anchorReal > 0 && this.checkpointHeaders.has(anchorCkpt)) {
       this.anchorHeight = anchorCkpt
       this.heightToFilterHeader.set(anchorCkpt, this.checkpointHeaders.get(anchorCkpt)!)
     } else {
@@ -552,7 +560,7 @@ export class CFilterSyncWorker extends Worker {
 
     while (this.cfHeaders.walkStart <= effectiveTip) {
       const startHeight = this.cfHeaders.walkStart
-      const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000 + 1
+      const nextCkpt = this.toInternal((Math.floor(this.toReal(startHeight) / 1000) + 1) * 1000)
       const stopHeight = Math.min(nextCkpt, effectiveTip)
       let fullyCached = true
       for (let h = startHeight; h <= stopHeight; h++) {
@@ -569,7 +577,7 @@ export class CFilterSyncWorker extends Worker {
     }
     this.emitStatus('cfheaders')
     const startHeight = this.cfHeaders.walkStart
-    const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000 + 1
+    const nextCkpt = this.toInternal((Math.floor(this.toReal(startHeight) / 1000) + 1) * 1000)
     const stopHeight = Math.min(nextCkpt, effectiveTip)
     if (!this.heightToBlockHash.has(stopHeight)) {
       console.warn(`[cfilter] cfheaders: no hash for h=${stopHeight}; stopping`)
@@ -595,7 +603,7 @@ export class CFilterSyncWorker extends Worker {
       candidates = [...this.peerPool.filterCapablePeers]
     }
     const picks = candidates.slice(0, CFHEADERS_RACE_PEERS)
-    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: toWireHeight(entry.startHeight), stopHash: stopHashWire})
+    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: this.toReal(entry.startHeight), stopHash: stopHashWire})
     for (const p of picks) {
       entry.triedPeers.add(p)
       p.sendMessage(msg)
@@ -684,7 +692,7 @@ export class CFilterSyncWorker extends Worker {
     if (racers.length === 0) return
     const msg = this.M.GetCFilters({
       filterType: FILTER_TYPE,
-      startHeight: toWireHeight(batch.startHeight),
+      startHeight: this.toReal(batch.startHeight),
       stopHash: batch.stopHashWire,
     })
     for (const p of racers) p.sendMessage(msg)

--- a/src/main/p2p/workers/CFilterSyncWorker.ts
+++ b/src/main/p2p/workers/CFilterSyncWorker.ts
@@ -116,6 +116,14 @@ function equalBytes(a: Uint8Array, b: Uint8Array): boolean {
   return true
 }
 
+// Chain heights here are 1-based (genesis = height 1, see GENESIS), but the
+// BIP157 start_height field is Dash Core's 0-based height. Convert when a
+// height crosses to the wire; the matching stop hash already resolves to the
+// peer's height, so only the numeric field needs shifting.
+function toWireHeight(internalHeight: number): number {
+  return internalHeight - 1
+}
+
 export class CFilterSyncWorker extends Worker {
   readonly name = 'CFilterSyncWorker'
 
@@ -454,7 +462,9 @@ export class CFilterSyncWorker extends Worker {
   private requestCheckpoints(): void {
     if (this.stopped) return
     this.cfcheckpt.responded = false
-    const stopHeight = Math.floor(this.effectiveScanTipHeight() / 1000) * 1000
+    // Checkpoints land on real heights that are multiples of 1000; in our
+    // 1-based numbering those are internal heights k*1000+1.
+    const stopHeight = Math.floor((this.effectiveScanTipHeight() - 1) / 1000) * 1000 + 1
     const stopHashWire = this.heightToBlockHash.get(stopHeight)
     if (!stopHashWire) {
       console.warn(`[cfilter] cfcheckpt: no hash for stop h=${stopHeight}, chain too short`)
@@ -496,8 +506,10 @@ export class CFilterSyncWorker extends Worker {
     this.leader = fromPeer
 
     const headers = msg.filterHeaders ?? []
+    // headers[i] is the filter header at real height (i+1)*1000; store it under
+    // the matching internal height (one higher in our 1-based numbering).
     for (let i = 0; i < headers.length; i++) {
-      this.checkpointHeaders.set((i + 1) * 1000, headers[i]!)
+      this.checkpointHeaders.set((i + 1) * 1000 + 1, headers[i]!)
     }
 
     // Cross-validate cached filter headers against checkpoints.
@@ -520,8 +532,8 @@ export class CFilterSyncWorker extends Worker {
     }
 
     const start = Math.max(this.birthdayHeight, this.cfilter.cursor)
-    const anchorCkpt = Math.floor((start - 1) / 1000) * 1000
-    if (anchorCkpt > 0 && this.checkpointHeaders.has(anchorCkpt)) {
+    const anchorCkpt = Math.floor((start - 1) / 1000) * 1000 + 1
+    if (anchorCkpt > 1 && this.checkpointHeaders.has(anchorCkpt)) {
       this.anchorHeight = anchorCkpt
       this.heightToFilterHeader.set(anchorCkpt, this.checkpointHeaders.get(anchorCkpt)!)
     } else {
@@ -540,7 +552,7 @@ export class CFilterSyncWorker extends Worker {
 
     while (this.cfHeaders.walkStart <= effectiveTip) {
       const startHeight = this.cfHeaders.walkStart
-      const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000
+      const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000 + 1
       const stopHeight = Math.min(nextCkpt, effectiveTip)
       let fullyCached = true
       for (let h = startHeight; h <= stopHeight; h++) {
@@ -557,7 +569,7 @@ export class CFilterSyncWorker extends Worker {
     }
     this.emitStatus('cfheaders')
     const startHeight = this.cfHeaders.walkStart
-    const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000
+    const nextCkpt = (Math.floor((startHeight - 1) / 1000) + 1) * 1000 + 1
     const stopHeight = Math.min(nextCkpt, effectiveTip)
     if (!this.heightToBlockHash.has(stopHeight)) {
       console.warn(`[cfilter] cfheaders: no hash for h=${stopHeight}; stopping`)
@@ -583,7 +595,7 @@ export class CFilterSyncWorker extends Worker {
       candidates = [...this.peerPool.filterCapablePeers]
     }
     const picks = candidates.slice(0, CFHEADERS_RACE_PEERS)
-    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: entry.startHeight, stopHash: stopHashWire})
+    const msg = this.M.GetCFHeaders({filterType: FILTER_TYPE, startHeight: toWireHeight(entry.startHeight), stopHash: stopHashWire})
     for (const p of picks) {
       entry.triedPeers.add(p)
       p.sendMessage(msg)
@@ -672,7 +684,7 @@ export class CFilterSyncWorker extends Worker {
     if (racers.length === 0) return
     const msg = this.M.GetCFilters({
       filterType: FILTER_TYPE,
-      startHeight: batch.startHeight,
+      startHeight: toWireHeight(batch.startHeight),
       stopHash: batch.stopHashWire,
     })
     for (const p of racers) p.sendMessage(msg)

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -112,4 +112,8 @@ export class WalletBackend {
 
     this.applicationService.markReady()
   }
+
+  async shutdown(): Promise<void> {
+    await this.walletSyncService?.shutdown()
+  }
 }

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -2,6 +2,7 @@ import {Block, Script, Transaction as SDKTransaction, utils as sdkUtils} from 'd
 import {UTXO} from '../types/UTXO'
 import {Transaction} from '../types/Transaction'
 import {TransactionDAO} from '../database/TransactionDAO'
+import {AddressDAO} from '../database/AddressDAO'
 import {WalletSyncService} from '../services/WalletSyncService'
 import {WalletProvider} from './WalletProvider'
 
@@ -20,6 +21,7 @@ export class P2PWalletProvider implements WalletProvider {
     private readonly transactionDAO: TransactionDAO,
     private readonly walletId: string,
     private readonly walletSyncService: WalletSyncService,
+    private readonly addressDAO: AddressDAO,
   ) {}
 
   async getTransactions(address: string): Promise<Transaction[]> {
@@ -57,7 +59,15 @@ export class P2PWalletProvider implements WalletProvider {
   }
 
   async nextUnusedAddress(): Promise<string> {
-    throw new Error('Not implemented')
+    const {receiving} = await this.addressDAO.getAddressesByWalletId(this.walletId)
+    if (receiving.length === 0) throw new Error('Wallet has no receiving addresses')
+
+    for (const {address} of receiving) {
+      const txs = await this.transactionDAO.getTransactionsByAddress(this.walletId, address)
+      if (txs.length === 0) return address
+    }
+
+    return receiving[receiving.length - 1].address
   }
 
   private p2pkhScript(address: string): Script {

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -91,7 +91,7 @@ export class WalletService {
 
   private getProvider(walletId: string, network: Network): WalletProvider {
     if (this.applicationService.preferences.general.connectionType === 'p2p') {
-      return new P2PWalletProvider(this.transactionDAO, walletId, this.walletSyncService)
+      return new P2PWalletProvider(this.transactionDAO, walletId, this.walletSyncService, this.addressDAO)
     }
     return new InsightWalletProvider(network, walletId, this.addressDAO)
   }

--- a/src/main/src/services/WalletSyncService.ts
+++ b/src/main/src/services/WalletSyncService.ts
@@ -175,6 +175,15 @@ export class WalletSyncService {
     this.ensureChild().postMessage(command)
   }
 
+  // Poll the locally-cached status until the utility process reports the given
+  // phase, or the timeout elapses. Used by shutdown to confirm chain.db closed.
+  private async waitForPhase(phase: WalletSyncStatus['phase'], timeoutMs: number): Promise<void> {
+    const start = Date.now()
+    while (this.status.phase !== phase && Date.now() - start < timeoutMs) {
+      await new Promise(resolve => setTimeout(resolve, 50))
+    }
+  }
+
   // Returns ack only — phase progression streams via getStatus, not the
   // return value. Returning a status snapshot here gave the renderer the
   // stale 'stopped' state because the utility process hadn't yet emitted
@@ -403,6 +412,11 @@ export class WalletSyncService {
     const exited = new Promise<void>((resolve) => {
       child.once('exit', () => resolve())
     })
+    // Ask the utility process to close chain.db (release the LevelDB lock)
+    // before we kill it. A hard kill leaves the lock held until the OS reaps
+    // the process, which can block the next launch's open.
+    this.send({ type: 'stop' })
+    await this.waitForPhase('stopped', 3000)
     child.kill()
     await exited
     this.child = null

--- a/src/renderer/src/hooks/useConnectionMode.ts
+++ b/src/renderer/src/hooks/useConnectionMode.ts
@@ -26,6 +26,7 @@ export function useConnectionMode(): UseConnectionMode {
   const { status } = useAuth()
   const phase = status?.walletSync.phase
   const walletId = status?.selectedWalletId ?? null
+  const activeSyncWalletId = status?.walletSync.walletId ?? null
   const [desired, setDesiredState] = useState<ConnectionType>(readDesired)
 
   const phaseRef = useRef<WalletSyncPhase | undefined>(phase)
@@ -52,6 +53,17 @@ export function useConnectionMode(): UseConnectionMode {
   const autoStartedFor = useRef<string | null>(null)
   useEffect(() => {
     if (!walletId) return
+
+    // A sync running for a different wallet than the selected one is stale
+    // (e.g. the user switched networks). Its phase/data belong to the old
+    // wallet — stop it. Once it reports 'stopped' this effect re-runs and the
+    // logic below decides whether to auto-start the newly-selected wallet.
+    if (activeSyncWalletId && activeSyncWalletId !== walletId && !isP2pInactive(phaseRef.current)) {
+      autoStartedFor.current = null
+      API.stopWalletSync().catch(err => console.error('stale stopWalletSync failed', err))
+      return
+    }
+
     if (desired !== 'p2p') return
     if (autoStartedFor.current === walletId) return
     if (!isP2pInactive(phaseRef.current)) {
@@ -70,7 +82,7 @@ export function useConnectionMode(): UseConnectionMode {
       })
       .catch(() => {})
     return () => { cancelled = true }
-  }, [walletId, desired, phase])
+  }, [walletId, desired, phase, activeSyncWalletId])
 
   const setDesired = useCallback((next: ConnectionType) => {
     localStorage.setItem(LS_DESIRED_KEY, next)


### PR DESCRIPTION
- Prevent chain.db lock contention on restart
- Stop stale p2p sync when the selected wallet changes
- Send BIP157 start_height as 0-based, align cf checkpoints
- Implement nextUnusedAddress in p2p mode
- Derive cf wire heights from per-network anchor offset