### PR TITLE
Settings: export recovery phrase + move wallet delete; fix send button

### DIFF
--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -7,6 +7,7 @@ declare global {
     electronAPI: {
       createWallet: (seedphrase: string, network: string, password: string) => Promise<unknown>
       verifyWalletPassword: (walletId: string, password: string) => Promise<boolean>
+      exportMnemonic: (walletId: string, password: string) => Promise<string>
       getAddresses: (walletId: string) => Promise<unknown>
       getReceiveAddress: (walletId: string) => Promise<string | null>
       getStatus: () => Promise<unknown>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -81,6 +81,10 @@ export class API {
     return this.api.verifyWalletPassword(walletId, password)
   }
 
+  static async exportMnemonic(walletId: string, password: string): Promise<string> {
+    return this.api.exportMnemonic(walletId, password)
+  }
+
   static async getExchangeRates(): Promise<ExchangeRatesResult> {
     return this.api.getExchangeRates() as Promise<ExchangeRatesResult>
   }

--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -4,7 +4,6 @@ import { useRipple } from '@renderer/hooks/useRipple'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { toDropdownOptions } from '@renderer/utils/wallets'
 import { useWallets, refreshWallets } from '@renderer/hooks/useWallets'
-import DeleteWallet from './modal/DeleteWallet'
 import DropdownSelect from './ui/DropdownSelect'
 import ConnectionSelect from './ui/ConnectionSelect'
 import SyncProgressBar from './ui/SyncProgressBar'
@@ -43,13 +42,6 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
   const { status, switchWallet, goToCreateWallet } = useAuth()
   const wallets = useWallets()
   const resolvedTheme = useResolvedTheme()
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false)
-  const [walletToDelete, setWalletToDelete] = useState<string | null>(null)
-
-  const openDeleteModal = (walletId: string) => {
-    setWalletToDelete(walletId)
-    setIsDeleteOpen(true)
-  }
 
   useEffect(() => {
     refreshWallets()
@@ -86,7 +78,6 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
             options={walletOptions}
             value={selectedWallet}
             onChange={handleWalletChange}
-            onItemAction={openDeleteModal}
             onAdd={goToCreateWallet}
             addLabel={"Add wallet"}
           />
@@ -115,15 +106,6 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
       <main className={"flex-1 mt-12"}>
         {children}
       </main>
-
-      <DeleteWallet
-        isDeleteOpen={isDeleteOpen}
-        setIsDeleteOpen={setIsDeleteOpen}
-        walletToDelete={walletToDelete}
-        setWalletToDelete={setWalletToDelete}
-        refreshWallets={refreshWallets}
-        selectedWallet={selectedWallet}
-      />
     </div>
   )
 }

--- a/src/renderer/src/components/modal/ExportMnemonic.tsx
+++ b/src/renderer/src/components/modal/ExportMnemonic.tsx
@@ -11,8 +11,6 @@ interface ExportMnemonicModalProps {
   walletId: string | null
 }
 
-type Phase = 'confirm' | 'revealed'
-
 export default function ExportMnemonic({
   isOpen,
   onClose,
@@ -20,7 +18,6 @@ export default function ExportMnemonic({
 }: ExportMnemonicModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
   const [password, setPassword] = useState('')
-  const [phase, setPhase] = useState<Phase>('confirm')
   const [error, setError] = useState<string | null>(null)
   const [words, setWords] = useState<string[]>([])
   const [loading, setLoading] = useState(false)
@@ -29,7 +26,6 @@ export default function ExportMnemonic({
   useEffect(() => {
     if (isOpen) {
       setPassword('')
-      setPhase('confirm')
       setError(null)
       setWords([])
       setLoading(false)
@@ -46,8 +42,8 @@ export default function ExportMnemonic({
     try {
       const mnemonic = await API.exportMnemonic(walletId, password)
       setWords(mnemonic.trim().split(/\s+/))
-      setPhase('revealed')
-    } catch {
+    } catch (e) {
+      console.error('exportMnemonic failed', e)
       setError('Incorrect password. Please try again.')
     } finally {
       setLoading(false)
@@ -85,7 +81,7 @@ export default function ExportMnemonic({
           </button>
         </div>
 
-        {phase === 'confirm' ? (
+        {words.length === 0 ? (
           <div className={"phase-fade-in"} key={"confirm"}>
             <Text size={14} weight={"medium"} color={"brand"} opacity={40} className={"mt-2 block"}>
               Enter your wallet password to reveal the secret recovery phrase.

--- a/src/renderer/src/components/modal/ExportMnemonic.tsx
+++ b/src/renderer/src/components/modal/ExportMnemonic.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { Button, CrossIcon, Input, Text } from '../dash-ui-kit-enxtended'
+import { useTheme } from 'dash-ui-kit/react'
+import { API } from '@renderer/api'
+import SeedPhraseWarning from '@renderer/components/pages/auth/SeedPhraseWarning'
+
+interface ExportMnemonicModalProps {
+  isOpen: boolean
+  onClose: () => void
+  walletId: string | null
+}
+
+type Phase = 'confirm' | 'revealed'
+
+export default function ExportMnemonic({
+  isOpen,
+  onClose,
+  walletId,
+}: ExportMnemonicModalProps): React.JSX.Element | null {
+  const { theme } = useTheme()
+  const [password, setPassword] = useState('')
+  const [phase, setPhase] = useState<Phase>('confirm')
+  const [error, setError] = useState<string | null>(null)
+  const [words, setWords] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      setPassword('')
+      setPhase('confirm')
+      setError(null)
+      setWords([])
+      setLoading(false)
+      setCopied(false)
+    }
+  }, [isOpen])
+
+  if (!isOpen) return null
+
+  const handleReveal = async (): Promise<void> => {
+    if (!walletId || password.length === 0 || loading) return
+    setLoading(true)
+    setError(null)
+    try {
+      const mnemonic = await API.exportMnemonic(walletId, password)
+      setWords(mnemonic.trim().split(/\s+/))
+      setPhase('revealed')
+    } catch {
+      setError('Incorrect password. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleCopy = (): void => {
+    navigator.clipboard
+      .writeText(words.join(' '))
+      .then(() => {
+        setCopied(true)
+        setTimeout(() => setCopied(false), 1600)
+      })
+      .catch(() => {})
+  }
+
+  return createPortal(
+    <div
+      className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
+      onClick={onClose}
+    >
+      <div
+        className={"w-full max-w-115 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className={"flex items-center justify-between"}>
+          <Text size={24} weight={"extrabold"} color={"brand"}>
+            Recovery phrase
+          </Text>
+          <button
+            className={"dash-text-default hover:opacity-60 cursor-pointer"}
+            onClick={onClose}
+          >
+            <CrossIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+          </button>
+        </div>
+
+        {phase === 'confirm' ? (
+          <div className={"phase-fade-in"} key={"confirm"}>
+            <Text size={14} weight={"medium"} color={"brand"} opacity={40} className={"mt-2 block"}>
+              Enter your wallet password to reveal the secret recovery phrase.
+            </Text>
+            <div className={"mt-4.5"}>
+              <Input
+                id={"export-mnemonic-password"}
+                type={"password"}
+                placeholder={"Wallet password"}
+                value={password}
+                variant={"outlined"}
+                onChange={(e) => {
+                  setError(null)
+                  setPassword(e.target.value)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleReveal()
+                }}
+                className={"h-14.25 rounded-[1.25rem] bg-transparent!"}
+                colorScheme={error ? 'error' : 'primary'}
+                disabled={loading}
+                autoFocus
+              />
+            </div>
+            <div
+              className={`
+                overflow-hidden transition-all duration-200
+                ${error ? 'max-h-12 opacity-100 mt-2' : 'max-h-0 opacity-0'}
+              `}
+            >
+              <Text size={12} weight={"medium"} color={"red"}>{error}</Text>
+            </div>
+
+            <div className={"mt-4.5 flex gap-2"}>
+              <Button
+                type={"button"}
+                onClick={onClose}
+                variant={"solid"}
+                colorScheme={theme === 'light' ? 'lightBlue-mint' : 'gray'}
+                size={"md"}
+                className={"flex-1 rounded-[.9375rem]"}
+                disabled={loading}
+              >
+                Cancel
+              </Button>
+              <Button
+                type={"button"}
+                onClick={handleReveal}
+                disabled={password.length === 0 || loading}
+                variant={"solid"}
+                colorScheme={"primary"}
+                size={"md"}
+                className={"flex-1 rounded-[.9375rem]"}
+              >
+                {loading ? 'Revealing…' : 'Reveal phrase'}
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className={"phase-fade-in"} key={"revealed"}>
+            <div className={"mt-4"}>
+              <SeedPhraseWarning
+                title={"Never share your recovery phrase"}
+                description={"Anyone with these words can spend your funds. Keep them offline and private."}
+              />
+            </div>
+
+            <div className={"mt-4 grid grid-cols-3 gap-2.5"}>
+              {words.map((word, index) => (
+                <div
+                  key={index}
+                  className={"flex items-center gap-2 px-3 py-2.5 rounded-[.9375rem] border border-dash-primary-dark-blue/35 dark:border-white/35"}
+                >
+                  <Text size={12} weight={"medium"} color={"default"} opacity={30} className={"shrink-0"}>
+                    {index + 1}.
+                  </Text>
+                  <Text size={12} weight={"medium"} color={"default"} className={"break-all"}>
+                    {word}
+                  </Text>
+                </div>
+              ))}
+            </div>
+
+            <div className={"mt-4.5 flex gap-2"}>
+              <Button
+                type={"button"}
+                onClick={handleCopy}
+                variant={"solid"}
+                colorScheme={"lightBlue-mint"}
+                size={"md"}
+                className={"flex-1 rounded-[.9375rem]"}
+              >
+                {copied ? 'Copied' : 'Copy to clipboard'}
+              </Button>
+              <Button
+                type={"button"}
+                onClick={onClose}
+                variant={"solid"}
+                colorScheme={"primary"}
+                size={"md"}
+                className={"flex-1 rounded-[.9375rem]"}
+              >
+                Done
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/renderer/src/components/modal/SendConfirmModal.tsx
+++ b/src/renderer/src/components/modal/SendConfirmModal.tsx
@@ -228,7 +228,7 @@ export default function SendConfirmModal({
                 onClick={handleConfirm}
                 disabled={password.length === 0 || sending}
                 variant={"solid"}
-                colorScheme={"brand-mint"}
+                colorScheme={"lightBlue-mint"}
                 size={"md"}
                 className={"flex-1 rounded-[.9375rem] gap-2"}
               >
@@ -281,7 +281,7 @@ export default function SendConfirmModal({
                 type={"button"}
                 onClick={onClose}
                 variant={"solid"}
-                colorScheme={"brand-mint"}
+                colorScheme={"lightBlue-mint"}
                 size={"md"}
                 className={"flex-1 rounded-[.9375rem]"}
               >

--- a/src/renderer/src/components/pages/settings/Page.tsx
+++ b/src/renderer/src/components/pages/settings/Page.tsx
@@ -10,6 +10,7 @@ import { ThemePreference } from '@renderer/utils/theme'
 import { transactionsToCsv, CsvTxRow } from '@renderer/utils/csv'
 import { WalletTxDto } from '@renderer/hooks/useWalletTransactions'
 import { useWallets, refreshWallets } from '@renderer/hooks/useWallets'
+import DeleteWallet from '@renderer/components/modal/DeleteWallet'
 
 interface SettingsRowProps {
   title: string
@@ -105,6 +106,15 @@ export default function Settings(): React.JSX.Element {
 
   const [walletName, setWalletName] = useState('')
   const [renamePending, setRenamePending] = useState(false)
+
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false)
+  const [walletToDelete, setWalletToDelete] = useState<string | null>(null)
+
+  const openDelete = (): void => {
+    if (!walletId) return
+    setWalletToDelete(walletId)
+    setIsDeleteOpen(true)
+  }
 
   useEffect(() => {
     setWalletName(currentLabel ?? '')
@@ -297,7 +307,28 @@ export default function Settings(): React.JSX.Element {
             onClick={handleClear}
           />
         </div>
+
+        <SectionLabel>Danger zone</SectionLabel>
+        <div className="flex flex-col">
+          <SettingsRow
+            title="Delete wallet"
+            description="Permanently remove this wallet from this device. Make sure you have its recovery phrase backed up first."
+            actionLabel="Delete wallet"
+            disabled={walletId === null}
+            destructive
+            onClick={openDelete}
+          />
+        </div>
       </div>
+
+      <DeleteWallet
+        isDeleteOpen={isDeleteOpen}
+        setIsDeleteOpen={setIsDeleteOpen}
+        walletToDelete={walletToDelete}
+        setWalletToDelete={setWalletToDelete}
+        refreshWallets={refreshWallets}
+        selectedWallet={walletId}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/pages/settings/Page.tsx
+++ b/src/renderer/src/components/pages/settings/Page.tsx
@@ -11,6 +11,7 @@ import { transactionsToCsv, CsvTxRow } from '@renderer/utils/csv'
 import { WalletTxDto } from '@renderer/hooks/useWalletTransactions'
 import { useWallets, refreshWallets } from '@renderer/hooks/useWallets'
 import DeleteWallet from '@renderer/components/modal/DeleteWallet'
+import ExportMnemonic from '@renderer/components/modal/ExportMnemonic'
 
 interface SettingsRowProps {
   title: string
@@ -109,6 +110,7 @@ export default function Settings(): React.JSX.Element {
 
   const [isDeleteOpen, setIsDeleteOpen] = useState(false)
   const [walletToDelete, setWalletToDelete] = useState<string | null>(null)
+  const [isMnemonicOpen, setIsMnemonicOpen] = useState(false)
 
   const openDelete = (): void => {
     if (!walletId) return
@@ -242,6 +244,17 @@ export default function Settings(): React.JSX.Element {
           />
         </div>
 
+        <SectionLabel>Security</SectionLabel>
+        <div className="flex flex-col">
+          <SettingsRow
+            title="Recovery phrase"
+            description="Reveal this wallet's secret recovery phrase. Anyone with these words can access your funds."
+            actionLabel="Reveal phrase"
+            disabled={walletId === null}
+            onClick={() => setIsMnemonicOpen(true)}
+          />
+        </div>
+
         <SectionLabel>Appearance</SectionLabel>
         <div className="flex flex-col">
           <SettingsRow
@@ -328,6 +341,12 @@ export default function Settings(): React.JSX.Element {
         setWalletToDelete={setWalletToDelete}
         refreshWallets={refreshWallets}
         selectedWallet={walletId}
+      />
+
+      <ExportMnemonic
+        isOpen={isMnemonicOpen}
+        onClose={() => setIsMnemonicOpen(false)}
+        walletId={walletId}
       />
     </div>
   )

--- a/src/renderer/src/components/ui/DropdownSelect.tsx
+++ b/src/renderer/src/components/ui/DropdownSelect.tsx
@@ -4,8 +4,7 @@ import { Text, Tooltip } from '@renderer/components/dash-ui-kit-enxtended'
 import {
   WalletIcon,
   ChevronIcon,
-  PlusIcon,
-  DeleteIcon
+  PlusIcon
 } from '@renderer/components/dash-ui-kit-enxtended/icons'
 import { useClickOutside } from '@renderer/hooks/useClickOutside'
 import { useRipple } from '@renderer/hooks/useRipple'
@@ -15,7 +14,6 @@ export interface DropdownSelectProps {
   options: WalletDropdownOption[]
   value: string
   onChange: (value: string) => void
-  onItemAction?: (value: string) => void
   onAdd?: () => void
   addLabel?: string
   className?: string
@@ -45,7 +43,6 @@ export default function DropdownSelect({
   options,
   value,
   onChange,
-  onItemAction,
   onAdd,
   addLabel = "Add wallet",
   className = "",
@@ -126,8 +123,8 @@ export default function DropdownSelect({
                 key={option.value}
                 onClick={() => handleSelect(option.value)}
                 className={`
-                  flex items-center justify-between gap-3
-                  pl-4 pr-2 h-12
+                  flex items-center gap-3
+                  px-4 h-12
                   cursor-pointer transition-colors
                   ${isTestnet
                     ? 'bg-dash-yellow/25 hover:bg-dash-yellow/40'
@@ -148,18 +145,6 @@ export default function DropdownSelect({
                     )}
                   </div>
                 </div>
-                {onItemAction && (
-                  <button
-                    type={"button"}
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      onItemAction(option.value)
-                    }}
-                    className={"flex items-center justify-center w-6 h-6 cursor-pointer rounded-md hover:bg-dash-primary-dark-blue/5 dark:hover:bg-white/5"}
-                  >
-                    <DeleteIcon size={12} color={"currentColor"} className={"dash-text-default"} />
-                  </button>
-                )}
               </div>
             )
 


### PR DESCRIPTION
## Summary
- **Move wallet delete to Settings.** Removed the per-item delete button from the wallet dropdown; deletion now lives in a "Danger zone" row on the Settings page (deletes the current wallet, reusing the existing confirmation modal).
- **Export recovery phrase UI.** New "Security -> Recovery phrase" row opens a password-gated modal that reveals the mnemonic (word grid + copy). Backend `exportMnemonic` already existed; this wires the missing preload type and renderer API wrapper, and adds the UI.
- **Fix Confirm & Send button text in dark theme.** `solid + brand-mint` had no compound variant in the Button component, so the text fell back to near-black. Switched the Confirm & Send and Done buttons to `lightBlue-mint` (green text in dark), matching the reveal modal.

