### PR TITLE
fix: asset lock funding fee strategy and resumability

### DIFF
--- a/src/main/src/services/AssetLockService.ts
+++ b/src/main/src/services/AssetLockService.ts
@@ -2,6 +2,7 @@ import {DashPlatformSDK} from 'dash-platform-sdk'
 import {
   AssetLockProofWASM,
   AddressFundingFromAssetLockTransitionWASM,
+  AddressFundsFeeStrategyStepWASM,
   OutputAddressNullableCreditsWASM,
   PrivateKeyWASM,
 } from 'dash-platform-sdk/types.js'
@@ -135,13 +136,8 @@ export class AssetLockService {
   }
 
   private async failState(state: AssetLockFundingState, txid: string | null, error: unknown): Promise<void> {
-    state.phase = 'error'
     state.error = error instanceof Error ? error.message : String(error)
-    if (txid != null) {
-      try {
-        await this.assetLockDAO.updateStatus(txid, 'error', {error: state.error})
-      } catch {}
-    }
+    state.phase = txid != null ? 'resumable' : 'error'
   }
 
   private async runNewFunding(walletId: string, toPlatformAddress: string, amountDuffs: bigint, password: string, state: AssetLockFundingState): Promise<void> {
@@ -239,7 +235,7 @@ export class AssetLockService {
     const unsignedSt = this.sdk.platformAddresses.createStateTransition('addressFundingFromAssetLock', {
       assetLockProof: proof,
       inputs: [],
-      feeStrategy: [],
+      feeStrategy: [AddressFundsFeeStrategyStepWASM.ReduceOutput(0)],
       inputWitness: [],
       outputs: [new OutputAddressNullableCreditsWASM(row.toPlatformAddress)],
       userFeeIncrease: 0,

--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -75,7 +75,7 @@ export default function AssetLockFundingModal({
           notified.current = true
           onSuccess()
         }
-        if (next.phase !== 'done' && next.phase !== 'error') {
+        if (next.phase !== 'done' && next.phase !== 'error' && next.phase !== 'resumable') {
           timer = setTimeout(() => { void poll() }, 3000)
         }
       } catch {
@@ -92,7 +92,7 @@ export default function AssetLockFundingModal({
 
   if (!isOpen) return null
 
-  const running = started && state != null && state.phase !== 'done' && state.phase !== 'error'
+  const running = started && state != null && state.phase !== 'done' && state.phase !== 'error' && state.phase !== 'resumable'
 
   const handleConfirm = async (): Promise<void> => {
     if (!walletId || password.length === 0 || busy || started) return
@@ -122,7 +122,7 @@ export default function AssetLockFundingModal({
   }
 
   const isDone = state?.phase === 'done'
-  const isError = started && state?.phase === 'error'
+  const isError = started && (state?.phase === 'error' || state?.phase === 'resumable')
 
   return createPortal(
     <div
@@ -233,6 +233,11 @@ export default function AssetLockFundingModal({
               <div className={"mt-3"}>
                 <HashField hash={state.txid} label={"L1 txid"} />
               </div>
+            )}
+            {state.phase === 'resumable' && (
+              <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-2 block"}>
+                The locked Dash is safe — you can resume this funding from the Send page.
+              </Text>
             )}
             <div className={"mt-4.5 flex gap-2"}>
               <Button type={"button"} onClick={onClose} variant={"solid"} colorScheme={"lightBlue-mint"} size={"md"} className={"flex-1 rounded-[.9375rem]"}>


### PR DESCRIPTION
- `addressFundingFromAssetLock` was created with an empty fee strategy, which DPP rejects ("Fee strategy must have at least one step") — now uses `ReduceOutput(0)`.
- A failure after the L1 broadcast marked the funding row as `error`, making it unresumable even though the Dash was already locked. The row now keeps its active status; the error is surfaced in-memory as a `resumable` phase, and the funding modal renders it as a terminal state with a resume hint.