### PR TITLE
feat: shielded address balances + shield to entered address

### DIFF
--- a/src/main/shielded/ShieldedEngine.ts
+++ b/src/main/shielded/ShieldedEngine.ts
@@ -212,7 +212,7 @@ export class ShieldedEngine {
       await this.initProver()
 
       const privateKey = await this.sdk.keyPair.derivePlatformAddressPrivateKey(seed, network, PLATFORM_ACCOUNT, source.index)
-      const recipient = this.sdk.keyPair.deriveShieldedAddress(seed, network, SHIELDED_ACCOUNT)
+      const recipient = OrchardAddressWASM.fromBech32m(command.recipient)
       const senderOvk = this.sdk.keyPair.deriveShieldedOutgoingViewingKey(seed, network, SHIELDED_ACCOUNT)
 
       const inputs = [new InputAddressWASM(source.platformAddress, source.nonce + 1, BigInt(source.balanceCredits))]

--- a/src/main/shielded/ShieldedEngine.ts
+++ b/src/main/shielded/ShieldedEngine.ts
@@ -86,7 +86,12 @@ export class ShieldedEngine {
         const value = note.note.value
         const isSpent = spent.has(note.index)
         if (!isSpent) balance += value
-        notes.push({ index: note.index, amount: value.toString(), spent: isSpent })
+        notes.push({
+          index: note.index,
+          amount: value.toString(),
+          spent: isSpent,
+          address: note.note.address.toBech32m(command.network),
+        })
       }
       notes.sort((a, b) => b.index - a.index)
 

--- a/src/main/shielded/types/messages.ts
+++ b/src/main/shielded/types/messages.ts
@@ -32,7 +32,7 @@ export type ShieldedCommand =
       recipient: string
       amountCredits: string
     }
-  | { type: 'shield'; requestId: string; network: Network; seed: Uint8Array; source: ShieldSource; amountCredits: string }
+  | { type: 'shield'; requestId: string; network: Network; seed: Uint8Array; source: ShieldSource; recipient: string; amountCredits: string }
 
 export type ShieldedEvent =
   | { type: 'proverStatus'; state: ShieldedProverState; error: string | null }

--- a/src/main/shielded/types/messages.ts
+++ b/src/main/shielded/types/messages.ts
@@ -9,6 +9,7 @@ export interface ShieldedNoteSnapshot {
   index: number
   amount: string
   spent: boolean
+  address: string
 }
 
 export interface ShieldSource {

--- a/src/main/src/api/wallet/shieldToPool.ts
+++ b/src/main/src/api/wallet/shieldToPool.ts
@@ -13,9 +13,10 @@ export class ShieldToPoolHandler {
     _event: IpcMainInvokeEvent,
     walletId: string,
     fromAddress: string,
+    toAddress: string,
     amountCredits: string,
     password: string,
   ): Promise<ShieldResult> => {
-    return this.platformAddressService.shieldToPool(walletId, fromAddress, BigInt(amountCredits), password)
+    return this.platformAddressService.shieldToPool(walletId, fromAddress, toAddress, BigInt(amountCredits), password)
   }
 }

--- a/src/main/src/services/PlatformAddressService.ts
+++ b/src/main/src/services/PlatformAddressService.ts
@@ -412,11 +412,15 @@ export class PlatformAddressService {
   async shieldToPool(
     walletId: string,
     fromPlatformAddress: string,
+    toShieldedAddress: string,
     amountCredits: bigint,
     password: string,
   ): Promise<ShieldResult> {
     if (amountCredits <= 0n) {
       throw new Error('Shield amount must be greater than zero')
+    }
+    if (toShieldedAddress.length === 0) {
+      throw new Error('Shielded recipient address is required')
     }
 
     const {wallet, seed, xpub} = await this.unlock(walletId, password)
@@ -431,7 +435,7 @@ export class PlatformAddressService {
       nonce: source.nonce,
       balanceCredits: source.balanceCredits.toString(),
       index: source.index,
-    }, amountCredits)
+    }, toShieldedAddress, amountCredits)
 
     return {
       stHash,

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -403,11 +403,11 @@ export class ShieldedService {
 
   // Proves and broadcasts a shield transition in the utility process on
   // behalf of PlatformAddressService. Resolves with the state transition hash.
-  shield(network: Network, seed: Uint8Array, source: ShieldSource, amountCredits: bigint): Promise<string> {
+  shield(network: Network, seed: Uint8Array, source: ShieldSource, recipient: string, amountCredits: bigint): Promise<string> {
     const requestId = randomUUID()
     return new Promise<string>((resolve, reject) => {
       this.pendingShields.set(requestId, {resolve, reject})
-      this.send({type: 'shield', requestId, network, seed, source, amountCredits: amountCredits.toString()})
+      this.send({type: 'shield', requestId, network, seed, source, recipient, amountCredits: amountCredits.toString()})
     })
   }
 

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -33,6 +33,7 @@ export interface ShieldedNoteInfo {
   index: number
   amount: string
   spent: boolean
+  address: string
 }
 
 export interface ShieldedSyncState {

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -28,7 +28,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   startAssetLockFunding: (walletId: string, toPlatformAddress: string, amountDuffs: string, password: string) => ipcRenderer.invoke('startAssetLockFunding', walletId, toPlatformAddress, amountDuffs, password),
   getAssetLockFundingState: (walletId: string) => ipcRenderer.invoke('getAssetLockFundingState', walletId),
   resumeAssetLockFunding: (walletId: string, password: string) => ipcRenderer.invoke('resumeAssetLockFunding', walletId, password),
-  shieldToPool: (walletId: string, fromAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('shieldToPool', walletId, fromAddress, amountCredits, password),
+  shieldToPool: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('shieldToPool', walletId, fromAddress, toAddress, amountCredits, password),
   // preferencess
   getPreferences: () => ipcRenderer.invoke('getPreferences'),
   setLanguage: (language: string) => ipcRenderer.invoke('setLanguage', language),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -34,7 +34,7 @@ declare global {
       startAssetLockFunding: (walletId: string, toPlatformAddress: string, amountDuffs: string, password: string) => Promise<unknown>
       getAssetLockFundingState: (walletId: string) => Promise<unknown>
       resumeAssetLockFunding: (walletId: string, password: string) => Promise<unknown>
-      shieldToPool: (walletId: string, fromAddress: string, amountCredits: string, password: string) => Promise<{ stHash: string; amountCredits: string; fromAddress: string }>
+      shieldToPool: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => Promise<{ stHash: string; amountCredits: string; fromAddress: string }>
       broadcastTransaction: (txHex: string) => Promise<unknown>
       getPreferences: () => Promise<unknown>
       setLanguage: (language: string) => Promise<unknown>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -161,8 +161,8 @@ export class API {
     return this.api.resumeAssetLockFunding(walletId, password) as Promise<AssetLockFundingState>
   }
 
-  static async shieldToPool(walletId: string, fromAddress: string, amountCredits: string, password: string): Promise<ShieldResult> {
-    return this.api.shieldToPool(walletId, fromAddress, amountCredits, password) as Promise<ShieldResult>
+  static async shieldToPool(walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string): Promise<ShieldResult> {
+    return this.api.shieldToPool(walletId, fromAddress, toAddress, amountCredits, password) as Promise<ShieldResult>
   }
 
   static async startShieldedTransfer(walletId: string, recipient: string, amountCredits: string, password: string): Promise<ShieldedSpendState> {

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -187,6 +187,7 @@ export interface ShieldedNoteInfo {
   index: number
   amount: string
   spent: boolean
+  address: string
 }
 
 export type ShieldedSyncPhase = 'idle' | 'syncing' | 'recovering' | 'done' | 'error'

--- a/src/renderer/src/components/modal/ShieldConfirmModal.tsx
+++ b/src/renderer/src/components/modal/ShieldConfirmModal.tsx
@@ -13,6 +13,7 @@ interface ShieldConfirmModalProps {
   onClose: () => void
   walletId: string | null
   fromAddress: string
+  toAddress: string
   amountCredits: string
   proverReady: boolean
   onSuccess: () => void
@@ -26,6 +27,7 @@ export default function ShieldConfirmModal({
   onClose,
   walletId,
   fromAddress,
+  toAddress,
   amountCredits,
   proverReady,
   onSuccess,
@@ -54,7 +56,7 @@ export default function ShieldConfirmModal({
     setPhase('shielding')
     setError(null)
     try {
-      const res = await API.shieldToPool(walletId, fromAddress, amountCredits, password)
+      const res = await API.shieldToPool(walletId, fromAddress, toAddress, amountCredits, password)
       setResult(res)
       setPhase('done')
       onSuccess()
@@ -106,9 +108,9 @@ export default function ShieldConfirmModal({
               </div>
               <div className={"flex justify-between items-center gap-4"}>
                 <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"shrink-0"}>To</Text>
-                <div className={"flex items-center gap-1.5"}>
-                  <ShieldSmallIcon size={14} className={"text-dash-brand dark:text-dash-mint"} />
-                  <Text size={12} weight={"medium"} color={"blue-mint"}>your shielded balance</Text>
+                <div className={"flex items-center gap-1.5 min-w-0"}>
+                  <ShieldSmallIcon size={14} className={"shrink-0 text-dash-brand dark:text-dash-mint"} />
+                  <Text size={12} weight={"medium"} color={"blue-mint"} className={"font-mono min-w-0 break-all text-right"}>{toAddress}</Text>
                 </div>
               </div>
             </div>
@@ -188,7 +190,7 @@ export default function ShieldConfirmModal({
                 {result ? result.amountCredits : ''} credits shielded
               </Text>
               <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>
-                Moved into your shielded balance. Re-sync notes to see it.
+                Moved into the shielded pool. If it went to your own address, re-sync notes to see it.
               </Text>
             </div>
 

--- a/src/renderer/src/components/pages/addresses/ShieldedAddressTab.tsx
+++ b/src/renderer/src/components/pages/addresses/ShieldedAddressTab.tsx
@@ -1,8 +1,12 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { BigNumber } from 'dash-ui-kit/react'
 import { Button, Input, Text, ShieldSmallIcon } from '@renderer/components/dash-ui-kit-enxtended'
 import CopyButton from '@renderer/components/ui/CopyButton'
 import ListSkeleton from '@renderer/components/ui/Skeleton'
+import ShieldedUnlockModal from '@renderer/components/modal/ShieldedUnlockModal'
 import { API } from '@renderer/api'
+import { useShieldedSyncState } from '@renderer/hooks/useShielded'
+import { formatCompactCredits } from '@renderer/utils/balance'
 
 export default function ShieldedAddressTab({ walletId }: { walletId: string | undefined }): React.JSX.Element {
   const [addresses, setAddresses] = useState<string[] | null>(null)
@@ -12,6 +16,20 @@ export default function ShieldedAddressTab({ walletId }: { walletId: string | un
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [showPasswordForm, setShowPasswordForm] = useState(false)
+
+  const [syncModalOpen, setSyncModalOpen] = useState(false)
+
+  const sync = useShieldedSyncState(walletId)
+  const synced = sync.phase === 'done'
+  const syncRunning = sync.phase === 'syncing' || sync.phase === 'recovering'
+  const balances = useMemo(() => {
+    const map = new Map<string, bigint>()
+    for (const note of sync.notes) {
+      if (note.spent) continue
+      map.set(note.address, (map.get(note.address) ?? 0n) + BigInt(note.amount))
+    }
+    return map
+  }, [sync.notes])
 
   useEffect(() => {
     setAddresses(null)
@@ -60,6 +78,20 @@ export default function ShieldedAddressTab({ walletId }: { walletId: string | un
   const handleConfirmAdd = (): Promise<void> => withPassword(async (pwd) => {
     setAddresses(await API.addShieldedAddress(walletId!, pwd))
   })
+
+  const handleSync = async (): Promise<void> => {
+    if (!walletId || syncRunning) return
+    if (unlockedPassword == null) {
+      setSyncModalOpen(true)
+      return
+    }
+    setError(null)
+    try {
+      await API.startShieldedSync(walletId, unlockedPassword)
+    } catch {
+      setError('Could not start sync. Please try again.')
+    }
+  }
 
   const handleNewAddress = async (): Promise<void> => {
     if (!walletId || busy) return
@@ -142,10 +174,23 @@ export default function ShieldedAddressTab({ walletId }: { walletId: string | un
             </Text>
             <CopyButton text={address} />
           </div>
+          <div className={"flex items-center gap-2 shrink-0"}>
+            {synced ? (
+              <Text size={14} weight={"medium"} color={"brand"}>
+                <span className={"font-bold"}>
+                  <BigNumber>{formatCompactCredits(balances.get(address) ?? 0n).toString()}</BigNumber>
+                </span>
+                {' Credits'}
+              </Text>
+            ) : (
+              <Text size={12} weight={"medium"} color={"brand"} opacity={40}>—</Text>
+            )}
+          </div>
         </div>
       ))}
       <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"px-1 leading-[130%]"}>
         Your Orchard shielded addresses. All of them receive into the same private balance — share any of them; incoming payments reveal nothing about sender, recipient or amount on-chain.
+        {!synced && !syncRunning && ' Sync your notes to see per-address balances.'}
       </Text>
       {showPasswordForm ? (
         <div className={"flex flex-col gap-3 p-5 rounded-[.9375rem] dash-block max-w-115"}>
@@ -168,19 +213,49 @@ export default function ShieldedAddressTab({ walletId }: { walletId: string | un
       ) : (
         <div className={"flex flex-col gap-2 items-start"}>
           {error && <Text size={12} weight={"medium"} color={"red"}>{error}</Text>}
-          <Button
-            type={"button"}
-            onClick={handleNewAddress}
-            disabled={!walletId || busy}
-            variant={"solid"}
-            colorScheme={"primary"}
-            size={"md"}
-            className={"rounded-[.9375rem]"}
-          >
-            {busy ? 'Deriving…' : 'New address'}
-          </Button>
+          {sync.phase === 'error' && (
+            <Text size={12} weight={"medium"} color={"red"}>{sync.error ?? 'Note sync failed.'}</Text>
+          )}
+          <div className={"flex items-center gap-2"}>
+            <Button
+              type={"button"}
+              onClick={handleNewAddress}
+              disabled={!walletId || busy}
+              variant={"solid"}
+              colorScheme={"primary"}
+              size={"md"}
+              className={"rounded-[.9375rem]"}
+            >
+              {busy ? 'Deriving…' : 'New address'}
+            </Button>
+            <Button
+              type={"button"}
+              onClick={handleSync}
+              disabled={!walletId || syncRunning}
+              variant={"solid"}
+              colorScheme={"lightBlue-mint"}
+              size={"md"}
+              className={"rounded-[.9375rem]"}
+            >
+              {syncRunning ? 'Syncing…' : synced ? 'Re-sync notes' : 'Sync notes'}
+            </Button>
+            {syncRunning && (
+              <Text size={12} weight={"medium"} color={"brand"} opacity={50}>
+                {sync.phase === 'recovering'
+                  ? 'Recovering your notes…'
+                  : sync.total > 0
+                    ? `Syncing notes ${sync.fetched.toLocaleString('en-US')} / ${sync.total.toLocaleString('en-US')}`
+                    : 'Syncing notes…'}
+              </Text>
+            )}
+          </div>
         </div>
       )}
+      <ShieldedUnlockModal
+        isOpen={syncModalOpen}
+        onClose={() => setSyncModalOpen(false)}
+        walletId={walletId ?? null}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -93,9 +93,6 @@ export default function TransferHub(): React.JSX.Element {
   const reason = unsupportedReason(fromKind, toKind)
   const info = operation ? operationInfo(operation) : null
   const shieldedInvolved = fromKind === 'shielded' || toKind === 'shielded'
-  // Shielding always credits this wallet's own derived shielded address —
-  // the backend never takes a recipient, so no address is asked for.
-  const shieldToOwn = operation === 'shield'
 
   const fundedAddresses = useMemo(
     () => platformAddresses.filter(a => BigInt(a.balanceCredits) > 0n),
@@ -152,11 +149,11 @@ export default function TransferHub(): React.JSX.Element {
     : toKind === 'platformAddress' ? isValidPlatformAddress(trimmedTo, network ?? undefined)
     : toKind === 'identity' ? isLikelyIdentityId(trimmedTo)
     : toKind === 'newIdentity' ? true
-    : shieldToOwn || isLikelyShieldedAddress(trimmedTo)
+    : isLikelyShieldedAddress(trimmedTo)
 
   const selfSend = operation === 'addressFundsTransfer' && destinationValid && selectedSource != null && trimmedTo === selectedSource.platformAddress
 
-  const destinationError = toKind === 'newIdentity' || shieldToOwn || trimmedTo.length === 0
+  const destinationError = toKind === 'newIdentity' || trimmedTo.length === 0
     ? null
     : !destinationValid
       ? (toKind === 'coreAddress' ? `Enter a valid Dash ${network ?? ''} address.`
@@ -267,14 +264,8 @@ export default function TransferHub(): React.JSX.Element {
           onValueChange={setToValue}
           placeholder={destinationPlaceholder}
           error={destinationError}
-          showValueInput={operation != null && !shieldToOwn}
+          showValueInput={operation != null}
         />
-      )}
-
-      {shieldToOwn && (
-        <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"px-1 leading-[130%]"}>
-          Credits are shielded to this wallet's own shielded address — nothing to enter.
-        </Text>
       )}
 
       {reason && (
@@ -356,7 +347,7 @@ export default function TransferHub(): React.JSX.Element {
     : fromKind === 'identity' ? (selectedIdentity?.identifier ?? '')
     : 'Your shielded balance'
 
-  const toDisplay = toKind === 'newIdentity' ? 'New identity' : shieldToOwn ? 'Your shielded balance' : trimmedTo
+  const toDisplay = toKind === 'newIdentity' ? 'New identity' : trimmedTo
 
   const confirmStep = (
     <div className={"flex flex-col gap-3"}>
@@ -512,6 +503,7 @@ export default function TransferHub(): React.JSX.Element {
           onClose={() => setConfirmOpen(false)}
           walletId={walletId}
           fromAddress={selectedSource?.platformAddress ?? ''}
+          toAddress={trimmedTo}
           amountCredits={amountCredits.toString()}
           proverReady={prover.ready}
           onSuccess={resetForm}


### PR DESCRIPTION
- Addresses → Shielded: per-address balances (summed from unspent synced notes) and a Sync notes button, no need to leave the page
- Send → Shielded: recipient input is back and now actually used — the shield transition credits the entered address instead of always deriving the wallet's own