### PR TITLE
feat: create identity from the shielded pool (shielded → new identity)

### DIFF
--- a/src/main/shielded/ShieldedEngine.ts
+++ b/src/main/shielded/ShieldedEngine.ts
@@ -1,5 +1,7 @@
 import {DashPlatformSDK} from 'dash-platform-sdk'
 import {
+  IdentityCreateFromShieldedPoolTransitionWASM,
+  IdentityPublicKeyInCreationWASM,
   OrchardAddressWASM,
   OutPointWASM,
   PrivateKeyWASM,
@@ -10,9 +12,10 @@ import {
   StateTransitionWASM,
   UnshieldTransitionWASM,
 } from 'pshenmic-dpp'
-import {InputAddressWASM, AddressFundsFeeStrategyStepWASM, AssetLockProofWASM} from 'dash-platform-sdk/types.js'
+import {InputAddressWASM, AddressFundsFeeStrategyStepWASM, AssetLockProofWASM, IdentityPublicKeyInCreation} from 'dash-platform-sdk/types.js'
 import {Network} from '../src/types'
 import {coreAddressToScript} from '../src/utils/coreScript'
+import {IDENTITY_KEY_DEFINITIONS} from '../src/utils/identityKeys'
 import {maxSpendableCredits, selectSpendNotes} from '../src/utils/shieldedNoteSelection'
 import {ShieldedCommand, ShieldedEvent, ShieldedNoteSnapshot, ShieldedSpendKind} from './types/messages'
 
@@ -129,10 +132,11 @@ export class ShieldedEngine {
         const unspent = recovered.filter((note) => !spent.has(note.index))
         if (unspent.length === 0) throw new Error('No shielded notes available to spend')
 
+        const feeCredits = kind === 'identityCreate' ? 0n : SPEND_FEE_CREDITS
         const selectable = unspent.map((note) => ({ index: note.index, value: note.note.value }))
-        const selection = selectSpendNotes(selectable, amount + SPEND_FEE_CREDITS, MAX_SPEND_NOTES)
+        const selection = selectSpendNotes(selectable, amount + feeCredits, MAX_SPEND_NOTES)
         if (selection == null) {
-          const max = maxSpendableCredits(selectable, MAX_SPEND_NOTES, SPEND_FEE_CREDITS)
+          const max = maxSpendableCredits(selectable, MAX_SPEND_NOTES, feeCredits)
           throw new Error(
             `Amount needs more than ${MAX_SPEND_NOTES} notes (transaction size limit). ` +
             `Max per transaction right now: ${max.toLocaleString('en-US')} credits. ` +
@@ -158,6 +162,18 @@ export class ShieldedEngine {
             ...base,
             outputAddress: command.recipient,
             unshieldAmount: amount,
+          })
+        } else if (kind === 'identityCreate') {
+          if (command.identityIndex == null || command.failureAddress == null) {
+            throw new Error('Identity creation needs an identity index and a failure refund address')
+          }
+          const keys = this.buildIdentityCreationKeys(seed, network, command.identityIndex)
+          stateTransition = await this.sdk.shielded.createStateTransition('identityCreateFromShieldedPool', {
+            ...base,
+            publicKeys: keys.publicKeys as unknown as IdentityPublicKeyInCreation[],
+            privateKeys: keys.privateKeys,
+            denomination: amount,
+            sendToAddressOnCreationFailure: command.failureAddress,
           })
         } else {
           stateTransition = await this.sdk.shielded.createStateTransition('shieldedWithdrawal', {
@@ -194,12 +210,16 @@ export class ShieldedEngine {
           hash: stateTransition.hash(false),
         })
 
+        const identityId = kind === 'identityCreate'
+          ? IdentityCreateFromShieldedPoolTransitionWASM.fromStateTransition(stateTransition).identityId.base58()
+          : null
+
         this.emit({type: 'spendProgress', requestId, phase: 'broadcasting', fetched: all.length, total: all.length})
         await this.sdk.stateTransitions.broadcast(stateTransition)
         this.emit({type: 'notesSpent', requestId, indexes: toSpend.map((note) => note.index)})
         await this.waitForResult(stateTransition, kind)
 
-        this.emit({type: 'spendResult', requestId, ok: true, stHash: stateTransition.hash(false), error: null})
+        this.emit({type: 'spendResult', requestId, ok: true, stHash: stateTransition.hash(false), identityId, error: null})
         return
       }
     } catch (e) {
@@ -320,8 +340,24 @@ export class ShieldedEngine {
       ? ShieldedTransferTransitionWASM.fromStateTransition(st)
       : kind === 'unshield'
         ? UnshieldTransitionWASM.fromStateTransition(st)
-        : ShieldedWithdrawalTransitionWASM.fromStateTransition(st)
+        : kind === 'identityCreate'
+          ? IdentityCreateFromShieldedPoolTransitionWASM.fromStateTransition(st)
+          : ShieldedWithdrawalTransitionWASM.fromStateTransition(st)
     return transition.actions.map((action) => action.nullifier)
+  }
+
+  private buildIdentityCreationKeys(seed: Uint8Array, network: Network, identityIndex: number): {publicKeys: IdentityPublicKeyInCreationWASM[]; privateKeys: PrivateKeyWASM[]} {
+    const hdKey = this.sdk.keyPair.seedToHdKey(seed, network)
+    const privateKeys = IDENTITY_KEY_DEFINITIONS.map(({id}) => {
+      const derived = this.sdk.keyPair.deriveIdentityPrivateKey(hdKey, identityIndex, id, network)
+      if (derived.privateKey == null) {
+        throw new Error(`Could not derive identity key ${id}`)
+      }
+      return PrivateKeyWASM.fromBytes(derived.privateKey, network)
+    })
+    const publicKeys = IDENTITY_KEY_DEFINITIONS.map(({id, purpose, securityLevel, keyType}, i) =>
+      new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, false, Uint8Array.from(privateKeys[i].getPublicKey().bytes())))
+    return {publicKeys, privateKeys}
   }
 
   // Identifies which of the candidate notes are already spent on-chain. Own

--- a/src/main/shielded/ShieldedEngine.ts
+++ b/src/main/shielded/ShieldedEngine.ts
@@ -1,7 +1,6 @@
 import {DashPlatformSDK} from 'dash-platform-sdk'
 import {
   IdentityCreateFromShieldedPoolTransitionWASM,
-  IdentityPublicKeyInCreationWASM,
   OrchardAddressWASM,
   OutPointWASM,
   PrivateKeyWASM,
@@ -170,7 +169,7 @@ export class ShieldedEngine {
           const keys = this.buildIdentityCreationKeys(seed, network, command.identityIndex)
           stateTransition = await this.sdk.shielded.createStateTransition('identityCreateFromShieldedPool', {
             ...base,
-            publicKeys: keys.publicKeys as unknown as IdentityPublicKeyInCreation[],
+            publicKeys: keys.publicKeys,
             privateKeys: keys.privateKeys,
             denomination: amount,
             sendToAddressOnCreationFailure: command.failureAddress,
@@ -346,7 +345,10 @@ export class ShieldedEngine {
     return transition.actions.map((action) => action.nullifier)
   }
 
-  private buildIdentityCreationKeys(seed: Uint8Array, network: Network, identityIndex: number): {publicKeys: IdentityPublicKeyInCreationWASM[]; privateKeys: PrivateKeyWASM[]} {
+  // The SDK's shielded.createStateTransition destructures plain
+  // {id, purpose, ...} objects and builds the WASM key instances itself —
+  // passing IdentityPublicKeyInCreationWASM here breaks (its field is keyId).
+  private buildIdentityCreationKeys(seed: Uint8Array, network: Network, identityIndex: number): {publicKeys: IdentityPublicKeyInCreation[]; privateKeys: PrivateKeyWASM[]} {
     const hdKey = this.sdk.keyPair.seedToHdKey(seed, network)
     const privateKeys = IDENTITY_KEY_DEFINITIONS.map(({id}) => {
       const derived = this.sdk.keyPair.deriveIdentityPrivateKey(hdKey, identityIndex, id, network)
@@ -355,8 +357,14 @@ export class ShieldedEngine {
       }
       return PrivateKeyWASM.fromBytes(derived.privateKey, network)
     })
-    const publicKeys = IDENTITY_KEY_DEFINITIONS.map(({id, purpose, securityLevel, keyType}, i) =>
-      new IdentityPublicKeyInCreationWASM(id, purpose, securityLevel, keyType, false, Uint8Array.from(privateKeys[i].getPublicKey().bytes())))
+    const publicKeys = IDENTITY_KEY_DEFINITIONS.map(({id, purpose, securityLevel, keyType}, i) => ({
+      id,
+      purpose,
+      securityLevel,
+      keyType,
+      readOnly: false,
+      data: Uint8Array.from(privateKeys[i].getPublicKey().bytes()),
+    }))
     return {publicKeys, privateKeys}
   }
 

--- a/src/main/shielded/types/messages.ts
+++ b/src/main/shielded/types/messages.ts
@@ -3,7 +3,7 @@ import {Network} from '../../src/types'
 export type ShieldedProverState = 'idle' | 'preparing' | 'ready' | 'error'
 export type ShieldedSyncPhase = 'idle' | 'syncing' | 'recovering' | 'done' | 'error'
 export type ShieldedSpendPhase = 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'
-export type ShieldedSpendKind = 'transfer' | 'unshield' | 'withdrawal'
+export type ShieldedSpendKind = 'transfer' | 'unshield' | 'withdrawal' | 'identityCreate'
 
 export interface ShieldedNoteSnapshot {
   index: number
@@ -31,6 +31,8 @@ export type ShieldedCommand =
       kind: ShieldedSpendKind
       recipient: string
       amountCredits: string
+      identityIndex?: number
+      failureAddress?: string
     }
   | { type: 'shield'; requestId: string; network: Network; seed: Uint8Array; source: ShieldSource; recipient: string; amountCredits: string }
   | {
@@ -53,6 +55,6 @@ export type ShieldedEvent =
   | { type: 'syncResult'; requestId: string; ok: boolean; balance: string | null; notes: ShieldedNoteSnapshot[]; error: string | null }
   | { type: 'spendProgress'; requestId: string; phase: ShieldedSpendPhase; fetched: number; total: number }
   | { type: 'notesSpent'; requestId: string; indexes: number[] }
-  | { type: 'spendResult'; requestId: string; ok: boolean; stHash: string | null; error: string | null }
+  | { type: 'spendResult'; requestId: string; ok: boolean; stHash: string | null; identityId?: string | null; error: string | null }
   | { type: 'shieldResult'; requestId: string; ok: boolean; stHash: string | null; error: string | null }
   | { type: 'error'; message: string }

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -63,6 +63,7 @@ import {GetShieldedSyncStateHandler} from './api/shielded/getShieldedSyncState'
 import {StartShieldedTransferHandler} from './api/shielded/startShieldedTransfer'
 import {StartShieldedUnshieldHandler} from './api/shielded/startShieldedUnshield'
 import {StartShieldedWithdrawalHandler} from './api/shielded/startShieldedWithdrawal'
+import {StartShieldedIdentityCreateHandler} from './api/shielded/startShieldedIdentityCreate'
 import {GetShieldedSpendStateHandler} from './api/shielded/getShieldedSpendState'
 import {GetShieldedAddressHandler} from './api/shielded/getShieldedAddress'
 import {GetShieldedAddressesHandler} from './api/shielded/getShieldedAddresses'
@@ -156,6 +157,7 @@ export class WalletBackend {
     ipcMain.handle('startShieldedTransfer', new StartShieldedTransferHandler(this.shieldedService).handle)
     ipcMain.handle('startShieldedUnshield', new StartShieldedUnshieldHandler(this.shieldedService).handle)
     ipcMain.handle('startShieldedWithdrawal', new StartShieldedWithdrawalHandler(this.shieldedService).handle)
+    ipcMain.handle('startShieldedIdentityCreate', new StartShieldedIdentityCreateHandler(this.shieldedService).handle)
     ipcMain.handle('getShieldedSpendState', new GetShieldedSpendStateHandler(this.shieldedService).handle)
     ipcMain.handle('getShieldedAddress', new GetShieldedAddressHandler(this.shieldedService).handle)
     ipcMain.handle('getShieldedAddresses', new GetShieldedAddressesHandler(this.shieldedService).handle)
@@ -186,10 +188,10 @@ export class WalletBackend {
     this.walletSyncService = new WalletSyncService(walletDAO, addressDAO, transactionDAO)
     this.ratesService = new RatesService()
     this.contactService = new ContactService(contactDAO)
-    this.shieldedService = new ShieldedService(sdkProvider, walletDAO, new ShieldedNoteDAO(knex))
+    this.identityRegistrationService = new IdentityRegistrationService(sdkProvider)
+    this.shieldedService = new ShieldedService(sdkProvider, walletDAO, identityDAO, new ShieldedNoteDAO(knex), this.identityRegistrationService)
     this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, transactionDAO, this.applicationService, this.walletSyncService, sdkProvider, calibratedIterations)
     this.platformAddressService = new PlatformAddressService(walletDAO, identityDAO, sdkProvider, this.shieldedService)
-    this.identityRegistrationService = new IdentityRegistrationService(sdkProvider)
     this.assetLockService = new AssetLockService(walletDAO, identityDAO, new AssetLockDAO(knex), this.walletService, this.shieldedService, sdkProvider, this.identityRegistrationService)
     this.sdkProvider = sdkProvider
     this.walletDAO = walletDAO

--- a/src/main/src/api/shielded/startShieldedIdentityCreate.ts
+++ b/src/main/src/api/shielded/startShieldedIdentityCreate.ts
@@ -1,0 +1,14 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { ShieldedService, ShieldedSpendState } from '../../services/ShieldedService'
+
+export class StartShieldedIdentityCreateHandler {
+  private shieldedService: ShieldedService
+
+  constructor(shieldedService: ShieldedService) {
+    this.shieldedService = shieldedService
+  }
+
+  handle = async (_event: IpcMainInvokeEvent, walletId: string, denominationCredits: string, password: string): Promise<ShieldedSpendState> => {
+    return this.shieldedService.startIdentityCreate(walletId, password, BigInt(denominationCredits))
+  }
+}

--- a/src/main/src/services/IdentityRegistrationService.ts
+++ b/src/main/src/services/IdentityRegistrationService.ts
@@ -4,10 +4,13 @@ import {
   utils as coreUtils,
 } from 'dash-core-sdk'
 import type {ChainAssetLockProofParams, InstantAssetLockProofParams} from 'dash-core-sdk/src/utils.js'
-import {KeyType, Purpose, SecurityLevel, PrivateKeyWASM, StateTransitionWASM} from 'dash-platform-sdk/types.js'
+import {KeyType, PrivateKeyWASM, StateTransitionWASM} from 'dash-platform-sdk/types.js'
 import {SdkProvider} from './SdkProvider'
 import {Network} from '../types'
+import {IDENTITY_KEY_DEFINITIONS} from '../utils/identityKeys'
 import {IDENTITY_LOCK_POLL_INTERVAL_MS, IDENTITY_LOCK_TIMEOUT_MS} from '../constants'
+
+export {IDENTITY_KEY_DEFINITIONS} from '../utils/identityKeys'
 
 export type AssetLockProof = InstantAssetLockProofParams | ChainAssetLockProofParams
 
@@ -16,18 +19,6 @@ const COIN_TYPE: Record<Network, number> = {mainnet: 5, testnet: 1}
 // Upper bound on the on-chain free-index scan — guards against an infinite
 // loop if Platform keeps reporting an identity for every derived auth key.
 const IDENTITY_INDEX_SCAN_LIMIT = 100
-
-// Protocol limits IdentityCreateTransition to 6 public keys. AUTH MEDIUM is
-// dropped (added later via IdentityUpdateTransition if needed); MASTER /
-// CRITICAL / HIGH plus ENCRYPTION / DECRYPTION / TRANSFER cover the common path.
-export const IDENTITY_KEY_DEFINITIONS = [
-  {id: 0, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.MASTER, keyType: KeyType.ECDSA_SECP256K1},
-  {id: 1, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1},
-  {id: 2, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.HIGH, keyType: KeyType.ECDSA_SECP256K1},
-  {id: 3, purpose: Purpose.ENCRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1},
-  {id: 4, purpose: Purpose.DECRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1},
-  {id: 5, purpose: Purpose.TRANSFER, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1},
-] as const
 
 // Domain primitives for L1 asset-lock + Platform identity-create. Orchestration
 // (decrypt, UTXO selection, broadcast, persistence) lives in the controller.

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -2,8 +2,10 @@ import { utilityProcess, UtilityProcess } from 'electron'
 import path from 'path'
 import { randomUUID } from 'crypto'
 import { SdkProvider } from './SdkProvider'
+import { IdentityRegistrationService } from './IdentityRegistrationService'
 import { Network } from '../types'
 import { WalletDAO } from '../database/WalletDAO'
+import { IdentityDAO } from '../database/IdentityDAO'
 import { ShieldedNoteDAO } from '../database/ShieldedNoteDAO'
 import { decryptMnemonic } from '../utils'
 import {
@@ -51,6 +53,7 @@ export interface ShieldedSpendState {
   fetched: number
   total: number
   stHash: string | null
+  identityId: string | null
   error: string | null
 }
 
@@ -69,7 +72,9 @@ const CHILD_OUTPUT_TAIL_LIMIT = 8192
 export class ShieldedService {
   private sdkProvider: SdkProvider
   private walletDAO: WalletDAO
+  private identityDAO: IdentityDAO
   private shieldedNoteDAO: ShieldedNoteDAO
+  private identityRegistrationService: IdentityRegistrationService
   private child: UtilityProcess | null = null
   private childOutputTail = ''
   private proverState: ShieldedProverState = 'idle'
@@ -79,12 +84,15 @@ export class ShieldedService {
   private addresses = new Map<string, string[]>()
   private pendingSyncs = new Map<string, string>()
   private pendingSpends = new Map<string, string>()
+  private pendingIdentityCreates = new Map<string, {walletId: string; identityIndex: number; network: Network}>()
   private pendingShields = new Map<string, {resolve: (stHash: string) => void; reject: (error: Error) => void}>()
 
-  constructor(sdkProvider: SdkProvider, walletDAO: WalletDAO, shieldedNoteDAO: ShieldedNoteDAO) {
+  constructor(sdkProvider: SdkProvider, walletDAO: WalletDAO, identityDAO: IdentityDAO, shieldedNoteDAO: ShieldedNoteDAO, identityRegistrationService: IdentityRegistrationService) {
     this.sdkProvider = sdkProvider
     this.walletDAO = walletDAO
+    this.identityDAO = identityDAO
     this.shieldedNoteDAO = shieldedNoteDAO
+    this.identityRegistrationService = identityRegistrationService
   }
 
   private ensureChild(): UtilityProcess {
@@ -144,10 +152,23 @@ export class ShieldedService {
       }
     }
     this.pendingSpends.clear()
+    this.pendingIdentityCreates.clear()
     for (const {reject} of this.pendingShields.values()) {
       reject(new Error(message))
     }
     this.pendingShields.clear()
+  }
+
+  private async persistCreatedIdentity(context: {walletId: string; identityIndex: number; network: Network}, identifier: string): Promise<void> {
+    const existing = await this.identityDAO.getByIdentifier(context.walletId, identifier)
+    if (existing != null) return
+    const coinType = context.network === 'mainnet' ? 5 : 1
+    await this.identityDAO.insertIdentity({
+      walletId: context.walletId,
+      identityIndex: context.identityIndex,
+      identifier,
+      derivationPath: `m/9'/${coinType}'/0'/0/${context.identityIndex}`,
+    }, null)
   }
 
   private onEvent(event: ShieldedEvent): void {
@@ -200,11 +221,18 @@ export class ShieldedService {
     }
     if (event.type === 'spendResult') {
       const state = this.stateForSpend(event.requestId)
+      const identityCreate = this.pendingIdentityCreates.get(event.requestId)
       this.pendingSpends.delete(event.requestId)
+      this.pendingIdentityCreates.delete(event.requestId)
       if (state == null) return
       if (event.ok) {
         state.stHash = event.stHash
+        state.identityId = event.identityId ?? null
         state.phase = 'done'
+        if (identityCreate != null && event.identityId != null) {
+          this.persistCreatedIdentity(identityCreate, event.identityId).catch(e =>
+            console.error('Failed to persist identity created from the shielded pool', e))
+        }
       } else {
         state.phase = 'error'
         state.error = event.error
@@ -279,7 +307,7 @@ export class ShieldedService {
     return list
   }
 
-  private async unlock(walletId: string, password: string): Promise<{seed: Uint8Array; network: Network}> {
+  private async unlock(walletId: string, password: string): Promise<{seed: Uint8Array; network: Network; mnemonic: string}> {
     const wallet = await this.walletDAO.getWalletById(walletId)
     if (wallet == null) throw new Error('Wallet not found')
 
@@ -297,7 +325,7 @@ export class ShieldedService {
       await this.walletDAO.setPlatformXpub(walletId, xpub)
     }
 
-    return {seed, network: wallet.network}
+    return {seed, network: wallet.network, mnemonic}
   }
 
   async getPoolInfo(network: Network): Promise<ShieldedPoolInfo> {
@@ -347,7 +375,7 @@ export class ShieldedService {
   }
 
   private idleSpendState(): ShieldedSpendState {
-    return { phase: 'idle', fetched: 0, total: 0, stHash: null, error: null }
+    return { phase: 'idle', fetched: 0, total: 0, stHash: null, identityId: null, error: null }
   }
 
   getSpendState(walletId: string): ShieldedSpendState {
@@ -372,7 +400,7 @@ export class ShieldedService {
       return current
     }
 
-    const state: ShieldedSpendState = { phase: 'syncing', fetched: 0, total: 0, stHash: null, error: null }
+    const state: ShieldedSpendState = { phase: 'syncing', fetched: 0, total: 0, stHash: null, identityId: null, error: null }
     this.spendStates.set(walletId, state)
 
     try {
@@ -393,6 +421,50 @@ export class ShieldedService {
         kind,
         recipient,
         amountCredits: amountCredits.toString(),
+      })
+    } catch (e) {
+      state.phase = 'error'
+      state.error = e instanceof Error ? e.message : String(e)
+    }
+    return state
+  }
+
+  async startIdentityCreate(walletId: string, password: string, denominationCredits: bigint): Promise<ShieldedSpendState> {
+    const current = this.spendStates.get(walletId)
+    if (current != null && (current.phase === 'syncing' || current.phase === 'proving' || current.phase === 'broadcasting')) {
+      return current
+    }
+
+    const state: ShieldedSpendState = { phase: 'syncing', fetched: 0, total: 0, stHash: null, identityId: null, error: null }
+    this.spendStates.set(walletId, state)
+
+    try {
+      if (denominationCredits <= 0n) throw new Error('Amount must be greater than zero')
+
+      const {seed, network, mnemonic} = await this.unlock(walletId, password)
+      await this.cacheAddresses(walletId, seed, network)
+      const spent = await this.shieldedNoteDAO.getSpentIndexes(walletId)
+
+      const localIdentities = await this.identityDAO.getIdentitiesByWalletId(walletId)
+      const startIndex = localIdentities.reduce((max, identity) => Math.max(max, identity.identityIndex + 1), 0)
+      const identityIndex = await this.identityRegistrationService.findNextIdentityIndex(mnemonic, startIndex, network)
+
+      const failureAddress = (await this.sdkProvider.getPlatformSDK(network).keyPair.derivePlatformAddress(seed, network, PLATFORM_ACCOUNT, 0)).toBech32m(network)
+
+      const requestId = randomUUID()
+      this.pendingSpends.set(requestId, walletId)
+      this.pendingIdentityCreates.set(requestId, {walletId, identityIndex, network})
+      this.send({
+        type: 'spend',
+        requestId,
+        network,
+        seed,
+        spentIndexes: [...spent],
+        kind: 'identityCreate',
+        recipient: '',
+        amountCredits: denominationCredits.toString(),
+        identityIndex,
+        failureAddress,
       })
     } catch (e) {
       state.phase = 'error'

--- a/src/main/src/utils/identityKeys.ts
+++ b/src/main/src/utils/identityKeys.ts
@@ -1,3 +1,17 @@
+import {KeyType, Purpose, SecurityLevel} from 'dash-platform-sdk/types.js'
+
+// Protocol limits IdentityCreateTransition to 6 public keys. AUTH MEDIUM is
+// dropped (added later via IdentityUpdateTransition if needed); MASTER /
+// CRITICAL / HIGH plus ENCRYPTION / DECRYPTION / TRANSFER cover the common path.
+export const IDENTITY_KEY_DEFINITIONS = [
+  {id: 0, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.MASTER, keyType: KeyType.ECDSA_SECP256K1},
+  {id: 1, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1},
+  {id: 2, purpose: Purpose.AUTHENTICATION, securityLevel: SecurityLevel.HIGH, keyType: KeyType.ECDSA_SECP256K1},
+  {id: 3, purpose: Purpose.ENCRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1},
+  {id: 4, purpose: Purpose.DECRYPTION, securityLevel: SecurityLevel.MEDIUM, keyType: KeyType.ECDSA_SECP256K1},
+  {id: 5, purpose: Purpose.TRANSFER, securityLevel: SecurityLevel.CRITICAL, keyType: KeyType.ECDSA_SECP256K1},
+] as const
+
 export interface IdentityKeyDescriptor {
   keyId: number
   purpose: string

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -60,6 +60,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   startShieldedTransfer: (walletId: string, recipient: string, amountCredits: string, password: string) => ipcRenderer.invoke('startShieldedTransfer', walletId, recipient, amountCredits, password),
   startShieldedUnshield: (walletId: string, outputAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('startShieldedUnshield', walletId, outputAddress, amountCredits, password),
   startShieldedWithdrawal: (walletId: string, coreAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('startShieldedWithdrawal', walletId, coreAddress, amountCredits, password),
+  startShieldedIdentityCreate: (walletId: string, denominationCredits: string, password: string) => ipcRenderer.invoke('startShieldedIdentityCreate', walletId, denominationCredits, password),
   getShieldedSpendState: (walletId: string) => ipcRenderer.invoke('getShieldedSpendState', walletId),
   getShieldedAddress: (walletId: string, password?: string) => ipcRenderer.invoke('getShieldedAddress', walletId, password),
   getShieldedAddresses: (walletId: string, password?: string) => ipcRenderer.invoke('getShieldedAddresses', walletId, password),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -60,7 +60,8 @@ declare global {
       startShieldedTransfer: (walletId: string, recipient: string, amountCredits: string, password: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; error: string | null }>
       startShieldedUnshield: (walletId: string, outputAddress: string, amountCredits: string, password: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; error: string | null }>
       startShieldedWithdrawal: (walletId: string, coreAddress: string, amountCredits: string, password: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; error: string | null }>
-      getShieldedSpendState: (walletId: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; error: string | null }>
+      startShieldedIdentityCreate: (walletId: string, denominationCredits: string, password: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; identityId: string | null; error: string | null }>
+      getShieldedSpendState: (walletId: string) => Promise<{ phase: 'idle' | 'syncing' | 'proving' | 'broadcasting' | 'done' | 'error'; fetched: number; total: number; stHash: string | null; identityId: string | null; error: string | null }>
       getShieldedAddress: (walletId: string, password?: string) => Promise<string | null>
       getShieldedAddresses: (walletId: string, password?: string) => Promise<string[] | null>
       addShieldedAddress: (walletId: string, password: string) => Promise<string[]>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -185,6 +185,10 @@ export class API {
     return this.api.startShieldedWithdrawal(walletId, coreAddress, amountCredits, password) as Promise<ShieldedSpendState>
   }
 
+  static async startShieldedIdentityCreate(walletId: string, denominationCredits: string, password: string): Promise<ShieldedSpendState> {
+    return this.api.startShieldedIdentityCreate(walletId, denominationCredits, password) as Promise<ShieldedSpendState>
+  }
+
   static async getShieldedSpendState(walletId: string): Promise<ShieldedSpendState> {
     return this.api.getShieldedSpendState(walletId) as Promise<ShieldedSpendState>
   }

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -213,5 +213,6 @@ export interface ShieldedSpendState {
   fetched: number
   total: number
   stHash: string | null
+  identityId: string | null
   error: string | null
 }

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -148,7 +148,7 @@ export default function ShieldedSpendModal({
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>
-            {isDone ? 'Sent privately' : title}
+            {isDone ? (spend?.identityId ? 'Identity created' : 'Sent privately') : title}
           </Text>
           <button
             className={"dash-text-default hover:opacity-60 cursor-pointer disabled:opacity-30 disabled:cursor-default"}
@@ -263,10 +263,17 @@ export default function ShieldedSpendModal({
           <div className={"phase-fade-in"} key={"done"}>
             <div className={"flex flex-col items-center text-center mt-5 mb-1"}>
               <div className={"success-pop"}><SuccessIcon size={56} /></div>
-              <Text size={16} weight={"extrabold"} color={"brand"} className={"mt-3"}>{sentAmount || amountCredits} credits sent</Text>
-              <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>Broadcast to Platform. Re-sync notes to update your balance.</Text>
+              <Text size={16} weight={"extrabold"} color={"brand"} className={"mt-3"}>
+                {spend?.identityId ? 'Identity created' : `${sentAmount || amountCredits} credits sent`}
+              </Text>
+              <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>
+                {spend?.identityId
+                  ? `Funded with ${sentAmount || amountCredits} credits from the pool (minus the Platform fee). Re-sync notes to update your balance.`
+                  : 'Broadcast to Platform. Re-sync notes to update your balance.'}
+              </Text>
             </div>
-            <div className={"mt-5 p-[.875rem] rounded-[.9375rem] dash-block-3"}>
+            <div className={"mt-5 flex flex-col gap-[.75rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>
+              {spend?.identityId && <HashField hash={spend.identityId} label={"Identity"} />}
               {spend?.stHash && <HashField hash={spend.stHash} />}
             </div>
             <div className={"mt-4.5 flex gap-2"}>

--- a/src/renderer/src/components/pages/identities/Page.tsx
+++ b/src/renderer/src/components/pages/identities/Page.tsx
@@ -61,7 +61,12 @@ export default function Identities(): React.JSX.Element {
     <div className={"w-full px-12 pb-12 "}>
       <div className={"relative shadow-[8px_0_64px_0_rgba(12,28,51,0.08)] dash-card-base rounded-3xl p-[.9375rem]"}>
         <div className={"absolute right-[.9375rem] top-[.9375rem] z-10"}>
-          <Button colorScheme={"lightBlue-mint"} size={"sm"} onClick={() => navigate('/send?from=core&to=newIdentity')}>
+          <Button
+            colorScheme={"lightBlue-mint"}
+            size={"sm"}
+            className={"min-h-0! py-2! rounded-[.75rem]"}
+            onClick={() => navigate('/send?from=core&to=newIdentity')}
+          >
             Register identity
           </Button>
         </div>

--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -26,6 +26,8 @@ import {
   unsupportedReason,
   operationInfo,
   isLikelyIdentityId,
+  isPoolIdentityDenomination,
+  POOL_IDENTITY_DENOMINATIONS,
 } from "@renderer/utils/transferMatrix";
 import { API } from "@renderer/api";
 import { AssetLockFundingState, PlatformAddressDto, ShieldedSpendState } from "@renderer/api/types";
@@ -176,6 +178,7 @@ export default function TransferHub(): React.JSX.Element {
     : amountCredits >= minCredits && amountCredits > 0n
       && (availableCredits === null || amountCredits + feeCredits <= availableCredits)
       && (shieldedMaxPerTx === null || amountCredits <= shieldedMaxPerTx)
+      && (operation !== 'identityCreateFromPool' || isPoolIdentityDenomination(amountCredits))
 
   const canSubmit = routeReady && amountReady && !(operation === 'coreSend' && syncIncomplete)
 
@@ -213,13 +216,15 @@ export default function TransferHub(): React.JSX.Element {
 
   const amountError = isDashUnit || amount.length === 0
     ? null
-    : amountCredits < minCredits
-      ? `Minimum is ${minCredits.toLocaleString('en-US')} credits.`
-      : availableCredits !== null && amountCredits + feeCredits > availableCredits
-        ? `Amount plus the ${feeCredits.toLocaleString('en-US')} credit fee exceeds this balance.`
-        : shieldedMaxPerTx !== null && amountCredits > shieldedMaxPerTx
-          ? `Limited to ${MAX_SPEND_NOTES} notes per transaction — max right now is ${shieldedMaxPerTx.toLocaleString('en-US')} credits.`
-          : null
+    : operation === 'identityCreateFromPool' && !isPoolIdentityDenomination(amountCredits)
+      ? 'Pick one of the fixed denominations above.'
+      : amountCredits < minCredits
+        ? `Minimum is ${minCredits.toLocaleString('en-US')} credits.`
+        : availableCredits !== null && amountCredits + feeCredits > availableCredits
+          ? `Amount plus the ${feeCredits.toLocaleString('en-US')} credit fee exceeds this balance.`
+          : shieldedMaxPerTx !== null && amountCredits > shieldedMaxPerTx
+            ? `Limited to ${MAX_SPEND_NOTES} notes per transaction — max right now is ${shieldedMaxPerTx.toLocaleString('en-US')} credits.`
+            : null
 
   const resetForm = (): void => {
     setToValue('')
@@ -334,6 +339,15 @@ export default function TransferHub(): React.JSX.Element {
         </div>
       )}
 
+      {operation === 'identityCreateFromPool' && (
+        <div className={"flex flex-col gap-[.375rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>
+          <Text size={14} weight={"extrabold"} color={"brand"}>New identity from the pool</Text>
+          <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"leading-[130%]"}>
+            Creates a new Platform identity funded privately from your shielded balance. The protocol only allows fixed funding denominations, and the Platform fee is deducted from the chosen amount — the identity starts with slightly less. If creation fails on-chain, the credits are refunded to your Platform address.
+          </Text>
+        </div>
+      )}
+
       {operation === 'shieldedWithdrawal' && (
         <div className={"flex flex-col gap-[.375rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>
           <Text size={14} weight={"extrabold"} color={"brand"}>Output becomes public</Text>
@@ -353,6 +367,22 @@ export default function TransferHub(): React.JSX.Element {
 
   const amountStep = (
     <div>
+      {operation === 'identityCreateFromPool' && (
+        <div className={"mb-3 flex flex-wrap gap-2"}>
+          {POOL_IDENTITY_DENOMINATIONS.map(denomination => (
+            <button
+              key={denomination.toString()}
+              type={"button"}
+              onClick={() => setAmount(denomination.toString())}
+              className={`px-4 py-2 rounded-[.75rem] cursor-pointer transition-opacity hover:opacity-90 ${amountCredits === denomination ? 'dash-bg-inverse' : 'dash-block-3'}`}
+            >
+              <Text size={12} weight={"extrabold"} color={amountCredits === denomination ? "blue-mint" : "brand"}>
+                {(Number(denomination) / 1e11).toLocaleString('en-US')} Dash in credits
+              </Text>
+            </button>
+          ))}
+        </div>
+      )}
       <AmountField
         value={amount}
         onChange={handleAmount}
@@ -438,10 +468,11 @@ export default function TransferHub(): React.JSX.Element {
 
   const startShieldedSpend = (password: string): Promise<ShieldedSpendState> => {
     if (!walletId) {
-      return Promise.resolve<ShieldedSpendState>({ phase: 'error', fetched: 0, total: 0, stHash: null, error: 'No wallet selected' })
+      return Promise.resolve<ShieldedSpendState>({ phase: 'error', fetched: 0, total: 0, stHash: null, identityId: null, error: 'No wallet selected' })
     }
     if (operation === 'shieldedTransfer') return API.startShieldedTransfer(walletId, trimmedTo, amountCredits.toString(), password)
     if (operation === 'unshield') return API.startShieldedUnshield(walletId, trimmedTo, amountCredits.toString(), password)
+    if (operation === 'identityCreateFromPool') return API.startShieldedIdentityCreate(walletId, amountCredits.toString(), password)
     return API.startShieldedWithdrawal(walletId, trimmedTo, amountCredits.toString(), password)
   }
 
@@ -479,7 +510,7 @@ export default function TransferHub(): React.JSX.Element {
   const isPlatformModalOperation = operation === 'addressFundsTransfer' || operation === 'identityTopUp'
     || operation === 'addressWithdrawal' || operation === 'identityWithdrawal'
     || operation === 'identityToAddress' || operation === 'identityToIdentity' || operation === 'identityCreate'
-  const isShieldedSpendOperation = operation === 'shieldedTransfer' || operation === 'unshield' || operation === 'shieldedWithdrawal'
+  const isShieldedSpendOperation = operation === 'shieldedTransfer' || operation === 'unshield' || operation === 'shieldedWithdrawal' || operation === 'identityCreateFromPool'
 
   return (
     <div className={"relative flex flex-col h-full pb-4"}>
@@ -566,8 +597,8 @@ export default function TransferHub(): React.JSX.Element {
           onClose={() => setConfirmOpen(false)}
           walletId={walletId}
           title={info?.title ?? 'Send'}
-          toLabel={operation === 'shieldedTransfer' ? 'To (shielded)' : operation === 'unshield' ? 'To (Platform)' : 'To (Core L1)'}
-          toValue={trimmedTo}
+          toLabel={operation === 'shieldedTransfer' ? 'To (shielded)' : operation === 'unshield' ? 'To (Platform)' : operation === 'identityCreateFromPool' ? 'Creates' : 'To (Core L1)'}
+          toValue={operation === 'identityCreateFromPool' ? 'New Platform identity with 6 keys' : trimmedTo}
           amountCredits={amountCredits.toString()}
           proverReady={prover.ready}
           start={startShieldedSpend}

--- a/src/renderer/src/utils/transferMatrix.ts
+++ b/src/renderer/src/utils/transferMatrix.ts
@@ -18,6 +18,7 @@ export type TransferOperation =
   | 'shieldedTransfer'
   | 'unshield'
   | 'shieldedWithdrawal'
+  | 'identityCreateFromPool'
 
 const MATRIX: Record<SourceKind, Partial<Record<DestinationKind, TransferOperation>>> = {
   core: {
@@ -42,6 +43,7 @@ const MATRIX: Record<SourceKind, Partial<Record<DestinationKind, TransferOperati
   shielded: {
     coreAddress: 'shieldedWithdrawal',
     platformAddress: 'unshield',
+    newIdentity: 'identityCreateFromPool',
     shielded: 'shieldedTransfer',
   },
 }
@@ -50,7 +52,6 @@ const COMBO_REASONS: Partial<Record<`${SourceKind}->${DestinationKind}`, string>
   'identity->newIdentity': 'Send to a Platform address first, then create the identity from it.',
   'identity->shielded': 'Send to a Platform address first, then shield from it.',
   'shielded->identity': 'Unshield to a Platform address first, then top up the identity from it.',
-  'shielded->newIdentity': 'This wallet does not support creating an identity from the shielded pool yet.',
 }
 
 export function resolveOperation(from: SourceKind, to: DestinationKind): TransferOperation | null {
@@ -89,10 +90,24 @@ const OPERATION_INFO: Record<TransferOperation, OperationInfo> = {
   shieldedTransfer: {title: 'Send privately', submitLabel: 'Send', unit: 'credits', feeCredits: 6_500_000n, minCredits: 500_000n},
   unshield: {title: 'Unshield', submitLabel: 'Unshield', unit: 'credits', feeCredits: 6_500_000n, minCredits: 500_000n},
   shieldedWithdrawal: {title: 'Withdraw to L1', submitLabel: 'Withdraw', unit: 'credits', feeCredits: 6_500_000n, minCredits: 500_000n},
+  identityCreateFromPool: {title: 'Create identity from pool', submitLabel: 'Create', unit: 'credits', feeCredits: 0n, minCredits: 10_000_000_000n},
 }
 
 export function operationInfo(operation: TransferOperation): OperationInfo {
   return OPERATION_INFO[operation]
+}
+
+// The protocol only lets identities exit the shielded pool at fixed
+// denominations (uniform amounts keep pool spends unlinkable).
+export const POOL_IDENTITY_DENOMINATIONS: readonly bigint[] = [
+  10_000_000_000n,
+  30_000_000_000n,
+  50_000_000_000n,
+  100_000_000_000n,
+]
+
+export function isPoolIdentityDenomination(amountCredits: bigint): boolean {
+  return POOL_IDENTITY_DENOMINATIONS.includes(amountCredits)
 }
 
 export function isLikelyIdentityId(value: string): boolean {

--- a/tests/unit/transferMatrix.test.ts
+++ b/tests/unit/transferMatrix.test.ts
@@ -4,6 +4,8 @@ import {
   unsupportedReason,
   operationInfo,
   isLikelyIdentityId,
+  isPoolIdentityDenomination,
+  POOL_IDENTITY_DENOMINATIONS,
   SOURCE_KINDS,
   DESTINATION_KINDS,
   SourceKind,
@@ -36,7 +38,7 @@ const EXPECTED: Record<SourceKind, Partial<Record<DestinationKind, string | null
     coreAddress: 'shieldedWithdrawal',
     platformAddress: 'unshield',
     identity: null,
-    newIdentity: null,
+    newIdentity: 'identityCreateFromPool',
     shielded: 'shieldedTransfer',
   },
 }
@@ -91,6 +93,21 @@ describe('operationInfo', () => {
     expect(operationInfo('coreSend')).toMatchObject({unit: 'dash', feeCredits: null})
     expect(operationInfo('assetLockShield')).toMatchObject({unit: 'dash', feeCredits: null})
     expect(operationInfo('identityTopUpL1')).toMatchObject({unit: 'dash', feeCredits: null, submitLabel: 'Top up'})
+  })
+})
+
+describe('isPoolIdentityDenomination', () => {
+  it('accepts exactly the protocol exit denominations', () => {
+    for (const denomination of POOL_IDENTITY_DENOMINATIONS) {
+      expect(isPoolIdentityDenomination(denomination)).toBe(true)
+    }
+    expect(isPoolIdentityDenomination(0n)).toBe(false)
+    expect(isPoolIdentityDenomination(20_000_000_000n)).toBe(false)
+    expect(isPoolIdentityDenomination(10_000_000_001n)).toBe(false)
+  })
+
+  it('matches the pool minimum in operationInfo', () => {
+    expect(operationInfo('identityCreateFromPool')).toMatchObject({unit: 'credits', minCredits: POOL_IDENTITY_DENOMINATIONS[0]})
   })
 })
 


### PR DESCRIPTION
Closes the last implementable gap in the transfer matrix: `shielded → newIdentity` via the `identityCreateFromShieldedPool` transition.

- **New `identityCreate` spend kind** in the shielded worker's spend pipeline (note sync → selection → Halo2 proof → stale-nullifier retry → broadcast). The worker derives the 6 DIP-13 identity keys from the seed (`IDENTITY_KEY_DEFINITIONS` moved to `utils/identityKeys.ts`), the proof-of-possession signatures are produced by the dpp builder.
- **Fixed exit denominations** — probing the dpp builder showed pool identity creation only accepts 10B / 30B / 50B / 100B credits (0.1–1 DASH), and the Platform fee is deducted *from* the denomination. The UI offers denomination chips and note selection targets the denomination with no added spend fee.
- `ShieldedService.startIdentityCreate` scans the next free identity index, passes a refund platform address (`sendToAddressOnCreationFailure`), and persists the created identity locally on success. `ShieldedSpendState` gains `identityId`.
- Remaining unsupported combos (identity → newIdentity/shielded, shielded → identity) have no direct protocol transition and keep their two-hop hints.
