### PR TITLE
InstantSend asset lock proofs for all fundings + SPV sync loss fixes

### DIFF
--- a/src/main/p2p/workers/CFilterSyncWorker.ts
+++ b/src/main/p2p/workers/CFilterSyncWorker.ts
@@ -773,11 +773,15 @@ export class CFilterSyncWorker extends Worker {
   private requestFullBlock(height: number, blockHashWire: Uint8Array): void {
     const key = bytesToHex(blockHashWire)
     if (this.blockFetch.inflight.has(key)) return
-    const target = this.pickBlockPeer(new Set())
-    if (!target) return
-    const entry: BlockRequest = {hashWire: blockHashWire, height, triedPeers: new Set([target]), timer: null}
+    const entry: BlockRequest = {hashWire: blockHashWire, height, triedPeers: new Set(), timer: null}
     this.blockFetch.inflight.set(key, entry)
-    target.sendMessage(this.M.GetData([{type: Inventory.TYPE.BLOCK, hash: blockHashWire}]))
+    const target = this.pickBlockPeer(new Set())
+    if (target) {
+      entry.triedPeers.add(target)
+      target.sendMessage(this.M.GetData([{type: Inventory.TYPE.BLOCK, hash: blockHashWire}]))
+    } else {
+      console.warn(`[cfilter] block h=${height} matched but no ready peers — retrying on timer`)
+    }
     this.armBlockRequestTimer(key, entry)
   }
 
@@ -794,7 +798,11 @@ export class CFilterSyncWorker extends Worker {
       if (!next) {
         entry.triedPeers.clear()
         next = this.pickBlockPeer(entry.triedPeers)
-        if (!next) return
+        if (!next) {
+          console.warn(`[cfilter] block h=${entry.height} retry — no ready peers, re-arming`)
+          this.armBlockRequestTimer(key, entry)
+          return
+        }
         console.warn(`[cfilter] block h=${entry.height} retry — no fresh peers, re-asking ${next.host}`)
       } else {
         console.warn(`[cfilter] block h=${entry.height} timeout — retrying via ${next.host} (tried ${entry.triedPeers.size})`)

--- a/src/main/shielded/ShieldedEngine.ts
+++ b/src/main/shielded/ShieldedEngine.ts
@@ -276,10 +276,16 @@ export class ShieldedEngine {
       }
       const privateKey = PrivateKeyWASM.fromBytes(derived.privateKey as Uint8Array, network)
 
-      const proof = AssetLockProofWASM.createChainAssetLockProof(
-        command.coreChainLockedHeight,
-        new OutPointWASM(command.txid, command.outputIndex),
-      )
+      const proof = command.assetLockProof.type === 'instantLock'
+        ? AssetLockProofWASM.createInstantAssetLockProof(
+            Uint8Array.from(Buffer.from(command.assetLockProof.instantLock, 'hex')),
+            Uint8Array.from(Buffer.from(command.assetLockProof.transaction, 'hex')),
+            command.outputIndex,
+          )
+        : AssetLockProofWASM.createChainAssetLockProof(
+            command.assetLockProof.coreChainLockedHeight,
+            new OutPointWASM(command.txid, command.outputIndex),
+          )
       const recipient = OrchardAddressWASM.fromBech32m(command.recipient)
       const senderOvk = this.sdk.keyPair.deriveShieldedOutgoingViewingKey(seed, network, SHIELDED_ACCOUNT)
 

--- a/src/main/shielded/types/messages.ts
+++ b/src/main/shielded/types/messages.ts
@@ -19,6 +19,10 @@ export interface ShieldSource {
   index: number
 }
 
+export type ShieldAssetLockProofParams =
+  | { type: 'chainLock'; coreChainLockedHeight: number }
+  | { type: 'instantLock'; instantLock: string; transaction: string }
+
 export type ShieldedCommand =
   | { type: 'initProver' }
   | { type: 'sync'; requestId: string; network: Network; seed: Uint8Array; spentIndexes: number[] }
@@ -42,7 +46,7 @@ export type ShieldedCommand =
       seed: Uint8Array
       txid: string
       outputIndex: number
-      coreChainLockedHeight: number
+      assetLockProof: ShieldAssetLockProofParams
       creditDerivationPath: string
       recipient: string
       shieldAmountCredits: string

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -32,6 +32,7 @@ import {GetWalletBalance} from "./api/wallet/getWalletBalance";
 import {SetAddressLabel} from "./api/wallet/setAddressLabel";
 import {SetWalletLabel} from "./api/wallet/setWalletLabel";
 import {SendTransactionHandler} from "./api/wallet/sendTransaction";
+import {GetTxLockStatusHandler} from "./api/wallet/getTxLockStatus";
 import {SendPlatformTransferHandler} from "./api/wallet/sendPlatformTransfer";
 import {TopUpIdentityFromAddressesHandler} from "./api/wallet/topUpIdentityFromAddresses";
 import {WithdrawPlatformCreditsHandler} from "./api/wallet/withdrawPlatformCredits";
@@ -122,6 +123,7 @@ export class WalletBackend {
     ipcMain.handle('setAddressLabel', new SetAddressLabel(this.walletService).handle)
     ipcMain.handle('setWalletLabel', new SetWalletLabel(this.walletService).handle)
     ipcMain.handle('sendTransaction', new SendTransactionHandler(this.walletService).handle)
+    ipcMain.handle('getTxLockStatus', new GetTxLockStatusHandler(this.walletService).handle)
     ipcMain.handle('sendPlatformTransfer', new SendPlatformTransferHandler(this.platformAddressService).handle)
     ipcMain.handle('topUpIdentityFromAddresses', new TopUpIdentityFromAddressesHandler(this.platformAddressService).handle)
     ipcMain.handle('withdrawPlatformCredits', new WithdrawPlatformCreditsHandler(this.platformAddressService).handle)

--- a/src/main/src/api/wallet/getTxLockStatus.ts
+++ b/src/main/src/api/wallet/getTxLockStatus.ts
@@ -1,0 +1,19 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { WalletService } from '../../services/WalletService'
+import { TxLockStatus } from '../../types/TxLockStatus'
+
+export class GetTxLockStatusHandler {
+  private walletService: WalletService
+
+  constructor(walletService: WalletService) {
+    this.walletService = walletService
+  }
+
+  handle = async (
+    _event: IpcMainInvokeEvent,
+    walletId: string,
+    txid: string,
+  ): Promise<TxLockStatus> => {
+    return this.walletService.getTxLockStatus(walletId, txid)
+  }
+}

--- a/src/main/src/database/TransactionDAO.ts
+++ b/src/main/src/database/TransactionDAO.ts
@@ -1,6 +1,7 @@
 import type {Knex} from 'knex'
 import type {AppliedBlock, AppliedTx, WalletSyncUtxo} from '../../p2p/types/walletSync'
 import type {Transaction, TransactionInput, TransactionOutput} from '../types/Transaction'
+import type {TxLockStatus} from '../types/TxLockStatus'
 
 // Re-exported so callers (services, future API handlers) can stay decoupled
 // from the p2p IPC types if/when the protocol drifts.
@@ -255,6 +256,18 @@ export class TransactionDAO {
     }))
   }
 
+  getTxLockStatus = async (walletId: string, txid: string): Promise<TxLockStatus> => {
+    const row = await this.knex('transactions')
+      .select('instant_locked', 'chainlocked', 'block_height')
+      .where({wallet_id: walletId, txid})
+      .first()
+    return {
+      instantLocked: Boolean(row?.instant_locked),
+      chainlocked: Boolean(row?.chainlocked),
+      confirmed: (row?.block_height ?? 0) > 0,
+    }
+  }
+
   markInstantLocked = async (walletId: string, txid: string): Promise<void> => {
     await this.knex('transactions')
       .where({wallet_id: walletId, txid})
@@ -370,6 +383,8 @@ export class TransactionDAO {
         't.txid as t_txid',
         't.block_height as t_block_height',
         't.block_time as t_block_time',
+        't.instant_locked as t_instant_locked',
+        't.chainlocked as t_chainlocked',
         this.knex.raw('length(t.raw) as t_size'),
         'o.vout as o_vout',
         'o.address as o_address',
@@ -411,6 +426,8 @@ export class TransactionDAO {
         't.txid as t_txid',
         't.block_height as t_block_height',
         't.block_time as t_block_time',
+        't.instant_locked as t_instant_locked',
+        't.chainlocked as t_chainlocked',
         this.knex.raw('length(t.raw) as t_size'),
         'o.vout as o_vout',
         'o.address as o_address',
@@ -456,7 +473,7 @@ async function abandonWithinTrx(trx: Knex.Transaction, walletId: string, txid: s
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function shapeRowsToTransactions(rows: any[], walletId: string): Transaction[] {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const byTxid = new Map<string, {blockHeight: number; blockTime: number; size: number; outputs: Map<number, any>; inputs: Map<number, any>}>()
+  const byTxid = new Map<string, {blockHeight: number; blockTime: number; size: number; locked: boolean; outputs: Map<number, any>; inputs: Map<number, any>}>()
 
   for (const row of rows) {
     let acc = byTxid.get(row.t_txid)
@@ -465,6 +482,7 @@ function shapeRowsToTransactions(rows: any[], walletId: string): Transaction[] {
         blockHeight: row.t_block_height,
         blockTime: row.t_block_time,
         size: row.t_size,
+        locked: Boolean(row.t_instant_locked) || Boolean(row.t_chainlocked),
         outputs: new Map(),
         inputs: new Map(),
       }
@@ -526,7 +544,7 @@ function shapeRowsToTransactions(rows: any[], walletId: string): Transaction[] {
       date: new Date(acc.blockTime * 1000),
       size: acc.size,
       blockHeight: acc.blockHeight,
-      status: 'Pending',
+      status: acc.locked ? 'Locked' : 'Pending',
       walletId,
       confirmations: 0,
       txid,

--- a/src/main/src/providers/InsightWalletProvider.ts
+++ b/src/main/src/providers/InsightWalletProvider.ts
@@ -7,6 +7,7 @@ import {Transaction} from '../types/Transaction'
 import {AddressDAO} from '../database/AddressDAO'
 import {processProviderTransactions} from '../utils'
 import {TransactionWalletProviderJSON} from './types'
+import {TxLockStatus} from '../types/TxLockStatus'
 
 const BASE_URLS: Record<Network, string> = {
   mainnet: 'https://insight.dash.org/insight-api',
@@ -108,6 +109,20 @@ export class InsightWalletProvider implements WalletProvider {
     const data = await response.json() as { txid: string }
 
     return data.txid
+  }
+
+  async getTxLockStatus(txid: string): Promise<TxLockStatus> {
+    try {
+      const response = await this.sendRequest(`${this.baseUrl}/tx/${txid}`)
+      const data = await response.json() as Partial<Pick<TransactionWalletProviderJSON, 'txlock' | 'confirmations'>>
+      return {
+        instantLocked: data.txlock === true,
+        chainlocked: false,
+        confirmed: (data.confirmations ?? 0) > 0,
+      }
+    } catch {
+      return {instantLocked: false, chainlocked: false, confirmed: false}
+    }
   }
 
   // TODO: walk receiving addresses and return the first one with no on-chain

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -5,6 +5,7 @@ import {TransactionDAO} from '../database/TransactionDAO'
 import {AddressDAO} from '../database/AddressDAO'
 import {WalletSyncService} from '../services/WalletSyncService'
 import {WalletProvider} from './WalletProvider'
+import {TxLockStatus} from '../types/TxLockStatus'
 
 const {addressToPublicKeyHash} = sdkUtils
 
@@ -52,6 +53,10 @@ export class P2PWalletProvider implements WalletProvider {
   async broadcastTx(tx: SDKTransaction): Promise<string> {
     const result = await this.walletSyncService.broadcastTransaction(tx.hex())
     return result.txid
+  }
+
+  async getTxLockStatus(txid: string): Promise<TxLockStatus> {
+    return this.transactionDAO.getTxLockStatus(this.walletId, txid)
   }
 
   async ensureReady(): Promise<void> {

--- a/src/main/src/providers/WalletProvider.ts
+++ b/src/main/src/providers/WalletProvider.ts
@@ -1,6 +1,7 @@
 import {Block, Transaction as SDKTransaction} from 'dash-core-sdk'
 import {UTXO} from '../types/UTXO'
 import {Transaction} from '../types/Transaction'
+import {TxLockStatus} from '../types/TxLockStatus'
 
 export interface WalletProvider {
   getTransactions(address: string): Promise<Transaction[]>
@@ -9,6 +10,7 @@ export interface WalletProvider {
   getBlockByHash(hash: string): Promise<Block>
   getUTXOs(address: string): Promise<UTXO[]>
   broadcastTx(tx: SDKTransaction): Promise<string>
+  getTxLockStatus(txid: string): Promise<TxLockStatus>
   ensureReady(): Promise<void>
   // Returns the next unused receiving address for the wallet — used by the
   // Receive tab and change-output selection. The provider decides what

--- a/src/main/src/services/AssetLockService.ts
+++ b/src/main/src/services/AssetLockService.ts
@@ -6,7 +6,7 @@ import {
   PrivateKeyWASM,
 } from 'dash-platform-sdk/types.js'
 import {OrchardAddressWASM, OutPointWASM} from 'pshenmic-dpp'
-import {Transaction as SDKTransaction} from 'dash-core-sdk'
+import {Transaction as SDKTransaction, utils as coreUtils} from 'dash-core-sdk'
 import {WalletDAO} from '../database/WalletDAO'
 import {IdentityDAO} from '../database/IdentityDAO'
 import {AssetLockDAO, AssetLockFundingKind, AssetLockFundingRow} from '../database/AssetLockDAO'
@@ -15,7 +15,7 @@ import {Wallet} from '../types/Wallet'
 import {WalletService} from './WalletService'
 import {ShieldedService} from './ShieldedService'
 import {SdkProvider} from './SdkProvider'
-import {IdentityRegistrationService} from './IdentityRegistrationService'
+import {AssetLockProof, IdentityRegistrationService} from './IdentityRegistrationService'
 import {decryptMnemonic} from '../utils'
 import {ASSET_LOCK_CREDIT_OUTPUT_INDEX, shieldAmountFromLockedDuffs} from '../utils/assetLockTx'
 
@@ -42,15 +42,9 @@ export interface AssetLockFundingState {
   error: string | null
 }
 
-const POLL_INTERVAL_MS = 15_000
-const MAX_POLL_ATTEMPTS = 240
 const SHIELDED_ACCOUNT = 0
 const PLATFORM_ACCOUNT = 0
 const ALREADY_IN_CHAIN_MESSAGE = 'state transition already in chain'
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
 
 export class AssetLockService {
   private walletDAO: WalletDAO
@@ -311,53 +305,37 @@ export class AssetLockService {
 
     state.phase = 'waitingChainLock'
 
-    const coreSDK = this.sdkProvider.getCoreSDK(network)
+    const decryptedMnemonic = decryptMnemonic(wallet.encryptedMnemonic, password)
+    const seed = sdk.keyPair.mnemonicToSeed(decryptedMnemonic)
 
-    let txHeight = 0
-    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS && txHeight <= 0; attempt++) {
-      try {
-        const dapiTx = await coreSDK.getTransaction(row.txid)
-        if (dapiTx.height > 0) {
-          txHeight = dapiTx.height
-          break
-        }
-      } catch {}
-      await sleep(POLL_INTERVAL_MS)
+    const tx = live?.tx ?? (row.txHex != null ? SDKTransaction.fromHex(row.txHex) : null)
+    if (tx == null) {
+      throw new Error('Funding record is missing the asset lock transaction')
     }
-    if (txHeight <= 0) {
-      throw new Error('Timed out waiting for the asset lock transaction to confirm — resume later')
-    }
-    state.txHeight = txHeight
 
-    let chainLockedHeight = 0
-    for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS && chainLockedHeight < txHeight; attempt++) {
-      try {
-        const status = await sdk.node.status()
-        const height = status.chain?.coreChainLockedHeight
-        if (height != null) {
-          state.chainLockedHeight = height
-          if (height >= txHeight) {
-            chainLockedHeight = height
-            break
-          }
-        }
-      } catch {}
-      await sleep(POLL_INTERVAL_MS)
+    let watchAddresses = live?.inputAddresses
+    if (watchAddresses == null) {
+      const hdKey = sdk.keyPair.seedToHdKey(seed, network)
+      const derived = await sdk.keyPair.derivePath(hdKey, row.creditDerivationPath)
+      if (!derived.privateKey) {
+        throw new Error('Failed to derive the asset lock credit key')
+      }
+      const creditKey = PrivateKeyWASM.fromBytes(derived.privateKey as Uint8Array, network)
+      watchAddresses = [sdk.keyPair.p2pkhAddress(creditKey.getPublicKey().bytes(), network)]
     }
-    if (chainLockedHeight < txHeight) {
-      throw new Error('Timed out waiting for a ChainLock covering the asset lock — resume later')
+
+    const assetLockProof = await this.identityRegistrationService.waitForAssetLockProof(tx, row.txid, watchAddresses, network)
+    if (assetLockProof.type === 'chainLock') {
+      state.chainLockedHeight = assetLockProof.coreChainLockedHeight
     }
 
     await this.assetLockDAO.updateStatus(row.txid, 'chainlocked')
 
     state.phase = 'broadcastingST'
 
-    const decryptedMnemonic = decryptMnemonic(wallet.encryptedMnemonic, password)
-    const seed = sdk.keyPair.mnemonicToSeed(decryptedMnemonic)
-
     const stHash = row.kind === 'shielded'
-      ? await this.broadcastShieldSt(row, seed, network, chainLockedHeight)
-      : await this.broadcastAddressFundingSt(row, seed, network, chainLockedHeight)
+      ? await this.broadcastShieldSt(row, seed, network, assetLockProof)
+      : await this.broadcastAddressFundingSt(row, seed, network, assetLockProof)
 
     state.stHash = stHash
     state.phase = 'done'
@@ -365,7 +343,7 @@ export class AssetLockService {
     await this.assetLockDAO.updateStatus(row.txid, 'done', {stHash})
   }
 
-  private async broadcastAddressFundingSt(row: AssetLockFundingRow, seed: Uint8Array, network: Network, chainLockedHeight: number): Promise<string> {
+  private async broadcastAddressFundingSt(row: AssetLockFundingRow, seed: Uint8Array, network: Network, assetLockProof: AssetLockProof): Promise<string> {
     const sdk = this.sdkProvider.getPlatformSDK(network)
     const hdKey = sdk.keyPair.seedToHdKey(seed, network)
     const derived = await sdk.keyPair.derivePath(hdKey, row.creditDerivationPath)
@@ -374,7 +352,9 @@ export class AssetLockService {
     }
     const creditKey = PrivateKeyWASM.fromBytes(derived.privateKey as Uint8Array, network)
 
-    const proof = AssetLockProofWASM.createChainAssetLockProof(chainLockedHeight, new OutPointWASM(row.txid, row.outputIndex))
+    const proof = assetLockProof.type === 'instantLock'
+      ? AssetLockProofWASM.createInstantAssetLockProof(coreUtils.hexToBytes(assetLockProof.instantLock), coreUtils.hexToBytes(assetLockProof.transaction), assetLockProof.outputIndex)
+      : AssetLockProofWASM.createChainAssetLockProof(assetLockProof.coreChainLockedHeight, new OutPointWASM(row.txid, row.outputIndex))
 
     const unsignedSt = sdk.platformAddresses.createStateTransition('addressFundingFromAssetLock', {
       assetLockProof: proof,
@@ -397,7 +377,7 @@ export class AssetLockService {
     return signedSt.hash(false)
   }
 
-  private async broadcastShieldSt(row: AssetLockFundingRow, seed: Uint8Array, network: Network, chainLockedHeight: number): Promise<string> {
+  private async broadcastShieldSt(row: AssetLockFundingRow, seed: Uint8Array, network: Network, assetLockProof: AssetLockProof): Promise<string> {
     const surplus = await this.sdkProvider.getPlatformSDK(network).keyPair.derivePlatformAddress(seed, network, PLATFORM_ACCOUNT, 0)
 
     await this.assetLockDAO.updateStatus(row.txid, 'st_broadcast')
@@ -405,7 +385,9 @@ export class AssetLockService {
     return this.shieldedService.shieldFromAssetLock(network, seed, {
       txid: row.txid,
       outputIndex: row.outputIndex,
-      coreChainLockedHeight: chainLockedHeight,
+      assetLockProof: assetLockProof.type === 'instantLock'
+        ? {type: 'instantLock', instantLock: assetLockProof.instantLock, transaction: assetLockProof.transaction}
+        : {type: 'chainLock', coreChainLockedHeight: assetLockProof.coreChainLockedHeight},
       creditDerivationPath: row.creditDerivationPath,
       recipient: row.toPlatformAddress,
       shieldAmountCredits: shieldAmountFromLockedDuffs(BigInt(row.amountDuffs)),

--- a/src/main/src/services/AssetLockService.ts
+++ b/src/main/src/services/AssetLockService.ts
@@ -311,14 +311,14 @@ export class AssetLockService {
 
     state.phase = 'waitingChainLock'
 
-    const provider = this.walletService.getProvider(walletId, network)
+    const coreSDK = this.sdkProvider.getCoreSDK(network)
 
     let txHeight = 0
     for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS && txHeight <= 0; attempt++) {
       try {
-        const tx = await provider.getTransactionByHash(row.txid)
-        if (tx.blockHeight > 0) {
-          txHeight = tx.blockHeight
+        const dapiTx = await coreSDK.getTransaction(row.txid)
+        if (dapiTx.height > 0) {
+          txHeight = dapiTx.height
           break
         }
       } catch {}

--- a/src/main/src/services/AssetLockService.ts
+++ b/src/main/src/services/AssetLockService.ts
@@ -35,6 +35,7 @@ export interface AssetLockFundingState {
   txid: string | null
   txHeight: number | null
   chainLockedHeight: number | null
+  lockKind: 'instant' | 'chain' | null
   stHash: string | null
   toPlatformAddress: string | null
   identityIdentifier: string | null
@@ -67,7 +68,7 @@ export class AssetLockService {
   }
 
   private idleState(): AssetLockFundingState {
-    return {phase: 'idle', kind: 'address', txid: null, txHeight: null, chainLockedHeight: null, stHash: null, toPlatformAddress: null, identityIdentifier: null, amountDuffs: null, error: null}
+    return {phase: 'idle', kind: 'address', txid: null, txHeight: null, chainLockedHeight: null, lockKind: null, stHash: null, toPlatformAddress: null, identityIdentifier: null, amountDuffs: null, error: null}
   }
 
   private isActive(state: AssetLockFundingState | undefined): boolean {
@@ -325,6 +326,7 @@ export class AssetLockService {
     }
 
     const assetLockProof = await this.identityRegistrationService.waitForAssetLockProof(tx, row.txid, watchAddresses, network)
+    state.lockKind = assetLockProof.type === 'instantLock' ? 'instant' : 'chain'
     if (assetLockProof.type === 'chainLock') {
       state.chainLockedHeight = assetLockProof.coreChainLockedHeight
     }
@@ -420,6 +422,7 @@ export class AssetLockService {
     }
     const watchAddresses = live?.inputAddresses ?? [sdk.keyPair.p2pkhAddress(fundingKey.getPublicKey().bytes(), network)]
     const assetLockProof = await this.identityRegistrationService.waitForAssetLockProof(tx, row.txid, watchAddresses, network)
+    state.lockKind = assetLockProof.type === 'instantLock' ? 'instant' : 'chain'
 
     await this.assetLockDAO.updateStatus(row.txid, 'chainlocked')
 

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -9,6 +9,7 @@ import { IdentityDAO } from '../database/IdentityDAO'
 import { ShieldedNoteDAO } from '../database/ShieldedNoteDAO'
 import { decryptMnemonic } from '../utils'
 import {
+  ShieldAssetLockProofParams,
   ShieldedCommand,
   ShieldedEvent,
   ShieldedProverState,
@@ -486,7 +487,7 @@ export class ShieldedService {
   shieldFromAssetLock(network: Network, seed: Uint8Array, params: {
     txid: string
     outputIndex: number
-    coreChainLockedHeight: number
+    assetLockProof: ShieldAssetLockProofParams
     creditDerivationPath: string
     recipient: string
     shieldAmountCredits: bigint
@@ -502,7 +503,7 @@ export class ShieldedService {
         seed,
         txid: params.txid,
         outputIndex: params.outputIndex,
-        coreChainLockedHeight: params.coreChainLockedHeight,
+        assetLockProof: params.assetLockProof,
         creditDerivationPath: params.creditDerivationPath,
         recipient: params.recipient,
         shieldAmountCredits: params.shieldAmountCredits.toString(),

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -21,6 +21,7 @@ import {QueryStatus} from "../types/QueryStatus";
 import {WalletBalance} from "../types/WalletBalance";
 import {Transaction} from "../types/Transaction";
 import {SendResult} from "../types/SendResult";
+import {TxLockStatus} from "../types/TxLockStatus";
 import {selectCoins, SelectableUtxo} from "../utils/coinSelection";
 import {dedupeTransactions} from "../utils/dedupeTransactions";
 import {CoreTransactionService, TransferInput} from "./CoreTransactionService";
@@ -443,6 +444,15 @@ export class WalletService {
       changeAddress: hasChange ? changeAddress : null,
       peersAcked: 0,
     }
+  }
+
+  async getTxLockStatus(walletId: string, txid: string): Promise<TxLockStatus> {
+    const wallet = await this.walletDAO.getWalletById(walletId)
+    if (wallet == null) {
+      throw new Error('Wallet not found')
+    }
+    const provider = this.getProvider(wallet.walletId, wallet.network)
+    return provider.getTxLockStatus(txid)
   }
 
   private async gatherTransferInputs(walletId: string, network: Network, amountDuffs: bigint): Promise<{

--- a/src/main/src/services/WalletSyncService.ts
+++ b/src/main/src/services/WalletSyncService.ts
@@ -8,7 +8,7 @@ import {AddressDAO} from '../database/AddressDAO'
 import {TransactionDAO} from '../database/TransactionDAO'
 import {P2PCommand, P2PEvent} from '../../p2p/types/messages'
 import {BroadcastResult} from '../../p2p/types/broadcast'
-import {AppliedTx, WalletSyncStatus, WalletSyncUtxo} from '../../p2p/types/walletSync'
+import {AppliedBlock, AppliedTx, WalletSyncStatus, WalletSyncUtxo} from '../../p2p/types/walletSync'
 import {randomUUID} from 'crypto'
 import {GENESIS} from '../../p2p/constants'
 import {QueryStatus} from '../types/QueryStatus'
@@ -99,9 +99,7 @@ export class WalletSyncService {
       if (data.type === 'status') {
         this.status = data.status
       } else if (data.type === 'blockApplied') {
-        this.transactionDAO.applyBlock(data.block).catch(err =>
-          console.error('[walletSync] applyBlock failed:', err)
-        )
+        this.persistAppliedBlock(data.block)
       } else if (data.type === 'cursorAdvanced') {
         this.transactionDAO.advanceCursor(data.walletId, data.height).catch(err =>
           console.error('[walletSync] advanceCursor failed:', err)
@@ -262,6 +260,16 @@ export class WalletSyncService {
 
   getStatus = (): WalletSyncStatus => {
     return this.status
+  }
+
+  private persistAppliedBlock = (block: AppliedBlock, attempt = 0): void => {
+    this.transactionDAO.applyBlock(block).catch(err => {
+      if (attempt < 2) {
+        setTimeout(() => this.persistAppliedBlock(block, attempt + 1), 1_000)
+      } else {
+        console.error(`[walletSync] applyBlock failed permanently at h=${block.height}:`, err)
+      }
+    })
   }
 
   hasSyncProgress = async (walletId: string): Promise<boolean> => {

--- a/src/main/src/services/WalletSyncService.ts
+++ b/src/main/src/services/WalletSyncService.ts
@@ -278,6 +278,8 @@ export class WalletSyncService {
       throw new Error('broadcastTransaction: p2p utility process not started — call startWalletSync first')
     }
     const requestId = randomUUID()
+    await this.pushWatchedTxids(txidFromHex(txHex)).catch(err =>
+      console.error('[walletSync] pushWatchedTxids failed:', err))
     const result = await new Promise<BroadcastResult>((resolve, reject) => {
       this.pendingBroadcasts.set(requestId, ({ok, result, errorMessage}) => {
         if (ok) {
@@ -298,8 +300,6 @@ export class WalletSyncService {
     if (this.activeWalletId && (result.peersAcked.length > 0 || result.peersPropagated.length > 0)) {
       await this.recordOptimisticSpend(this.activeWalletId, txHex).catch(err =>
         console.error('[walletSync] recordOptimisticSpend failed:', err))
-      await this.pushWatchedTxids().catch(err =>
-        console.error('[walletSync] pushWatchedTxids failed:', err))
     }
     return result
   }
@@ -347,10 +347,11 @@ export class WalletSyncService {
   }
 
   // Tell the worker which unconfirmed local txids to watch for an isdlock.
-  private async pushWatchedTxids(): Promise<void> {
+  private async pushWatchedTxids(extraTxid?: string): Promise<void> {
     if (!this.activeWalletId || !this.child) return
     const pending = await this.transactionDAO.getPendingTxs(this.activeWalletId)
     const txids = pending.filter(p => !p.instantLocked).map(p => p.txid)
+    if (extraTxid && !txids.includes(extraTxid)) txids.push(extraTxid)
     this.send({type: 'watchTxs', walletId: this.activeWalletId, txids})
   }
 
@@ -437,6 +438,14 @@ export class WalletSyncService {
       lastError: null,
       updatedAt: Date.now(),
     }
+  }
+}
+
+function txidFromHex(txHex: string): string | undefined {
+  try {
+    return SDKTransaction.fromHex(txHex).hash()
+  } catch {
+    return undefined
   }
 }
 

--- a/src/main/src/types/TxLockStatus.ts
+++ b/src/main/src/types/TxLockStatus.ts
@@ -1,0 +1,5 @@
+export interface TxLockStatus {
+  instantLocked: boolean
+  chainlocked: boolean
+  confirmed: boolean
+}

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -20,6 +20,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   setAddressLabel: (walletId: string, address: string, label: string) => ipcRenderer.invoke('setAddressLabel', walletId, address, label),
   setWalletLabel: (walletId: string, label: string | null) => ipcRenderer.invoke('setWalletLabel', walletId, label),
   sendTransaction: (walletId: string, toAddress: string, amountDuffs: string, password: string) => ipcRenderer.invoke('sendTransaction', walletId, toAddress, amountDuffs, password),
+  getTxLockStatus: (walletId: string, txid: string) => ipcRenderer.invoke('getTxLockStatus', walletId, txid),
   sendPlatformTransfer: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('sendPlatformTransfer', walletId, fromAddress, toAddress, amountCredits, password),
   topUpIdentityFromAddresses: (walletId: string, identityId: string, fromAddress: string | null, amountCredits: string, password: string) => ipcRenderer.invoke('topUpIdentityFromAddresses', walletId, identityId, fromAddress, amountCredits, password),
   withdrawPlatformCredits: (walletId: string, fromAddress: string | null, toCoreAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('withdrawPlatformCredits', walletId, fromAddress, toCoreAddress, amountCredits, password),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -26,6 +26,7 @@ declare global {
       setAddressLabel: (walletId: string, address: string, label: string) => Promise<unknown>
       setWalletLabel: (walletId: string, label: string | null) => Promise<{ success: boolean; errorMessage: string | null }>
       sendTransaction: (walletId: string, toAddress: string, amountDuffs: string, password: string) => Promise<unknown>
+      getTxLockStatus: (walletId: string, txid: string) => Promise<unknown>
       sendPlatformTransfer: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => Promise<unknown>
       topUpIdentityFromAddresses: (walletId: string, identityId: string, fromAddress: string | null, amountCredits: string, password: string) => Promise<unknown>
       withdrawPlatformCredits: (walletId: string, fromAddress: string | null, toCoreAddress: string, amountCredits: string, password: string) => Promise<unknown>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -1,4 +1,4 @@
-import { AssetLockFundingKind, AssetLockFundingState, ConnectionType, Contact, ExchangeRatesResult, IdentityCreateResult, Network, PlatformAddressDto, PlatformSendResult, PreferencesJSON, QueryStatus, SendResult, ShieldResult, ShieldedPoolInfo, ShieldedSpendState, ShieldedStatus, ShieldedSyncState } from './types'
+import { AssetLockFundingKind, AssetLockFundingState, ConnectionType, Contact, ExchangeRatesResult, IdentityCreateResult, Network, PlatformAddressDto, PlatformSendResult, PreferencesJSON, QueryStatus, SendResult, ShieldResult, ShieldedPoolInfo, ShieldedSpendState, ShieldedStatus, ShieldedSyncState, TxLockStatus } from './types'
 
 export class API {
   private static get api() {
@@ -111,6 +111,10 @@ export class API {
 
   static async sendTransaction(walletId: string, toAddress: string, amountDuffs: string, password: string): Promise<SendResult> {
     return this.api.sendTransaction(walletId, toAddress, amountDuffs, password) as Promise<SendResult>
+  }
+
+  static async getTxLockStatus(walletId: string, txid: string): Promise<TxLockStatus> {
+    return this.api.getTxLockStatus(walletId, txid) as Promise<TxLockStatus>
   }
 
   static async getShieldedStatus(): Promise<ShieldedStatus> {

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -157,6 +157,7 @@ export interface AssetLockFundingState {
   txid: string | null
   txHeight: number | null
   chainLockedHeight: number | null
+  lockKind: 'instant' | 'chain' | null
   stHash: string | null
   toPlatformAddress: string | null
   identityIdentifier: string | null

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -125,6 +125,12 @@ export interface SendResult {
   peersAcked: number
 }
 
+export interface TxLockStatus {
+  instantLocked: boolean
+  chainlocked: boolean
+  confirmed: boolean
+}
+
 export interface PlatformSendResult {
   stHash: string
   amountCredits: string

--- a/src/renderer/src/components/modal/AddressQrModal.tsx
+++ b/src/renderer/src/components/modal/AddressQrModal.tsx
@@ -20,11 +20,9 @@ export default function AddressQrModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={onClose}
     >
       <div
         className={"w-full max-w-86 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={20} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -23,24 +23,31 @@ interface AssetLockFundingModalProps {
 const PHASE_LABELS: Record<AssetLockFundingKind, ReadonlyArray<{key: string; label: string}>> = {
   address: [
     { key: 'broadcastingL1', label: 'Broadcasting the L1 asset lock transaction' },
-    { key: 'waitingChainLock', label: 'Waiting for a ChainLock (takes a few minutes)' },
+    { key: 'waitingChainLock', label: 'Waiting for a network lock' },
     { key: 'broadcastingST', label: 'Crediting the Platform address' },
   ],
   shielded: [
     { key: 'broadcastingL1', label: 'Broadcasting the L1 asset lock transaction' },
-    { key: 'waitingChainLock', label: 'Waiting for a ChainLock (takes a few minutes)' },
+    { key: 'waitingChainLock', label: 'Waiting for a network lock' },
     { key: 'broadcastingST', label: 'Proving and shielding the credits' },
   ],
   identity: [
     { key: 'broadcastingL1', label: 'Broadcasting the L1 asset lock transaction' },
-    { key: 'waitingChainLock', label: 'Waiting for the network lock (instant or chain lock)' },
+    { key: 'waitingChainLock', label: 'Waiting for a network lock' },
     { key: 'broadcastingST', label: 'Registering the identity on Platform' },
   ],
   identityTopUp: [
     { key: 'broadcastingL1', label: 'Broadcasting the L1 asset lock transaction' },
-    { key: 'waitingChainLock', label: 'Waiting for the network lock (instant or chain lock)' },
+    { key: 'waitingChainLock', label: 'Waiting for a network lock' },
     { key: 'broadcastingST', label: 'Topping up the identity on Platform' },
   ],
+}
+
+function lockStepLabel(state: AssetLockFundingState, active: boolean): string {
+  if (state.lockKind === 'instant') return 'InstantSend lock received'
+  if (state.lockKind === 'chain') return 'ChainLock received'
+  if (active) return 'Waiting for an InstantSend lock (usually seconds; ChainLock fallback takes minutes)'
+  return 'Network lock (InstantSend or ChainLock)'
 }
 
 const TEXTS: Record<AssetLockFundingKind, {title: string; resumeTitle: string; doneTitle: string; doneHeading: string; doneNote: string; toLabel: string; emptyTo: string; confirm: string}> = {
@@ -138,10 +145,10 @@ export default function AssetLockFundingModal({
           onSuccess()
         }
         if (next.phase !== 'done' && next.phase !== 'error' && next.phase !== 'resumable') {
-          timer = setTimeout(() => { void poll() }, 3000)
+          timer = setTimeout(() => { void poll() }, 1500)
         }
       } catch {
-        if (!dead) timer = setTimeout(() => { void poll() }, 3000)
+        if (!dead) timer = setTimeout(() => { void poll() }, 1500)
       }
     }
     void poll()
@@ -225,7 +232,7 @@ export default function AssetLockFundingModal({
             </div>
 
             <Text size={14} weight={"medium"} color={"brand"} opacity={40} className={"mt-4 block"}>
-              Enter your wallet password. The funding waits for a ChainLock on the L1 transaction, which takes a few minutes. If the app is closed meanwhile, the funding can be resumed.
+              Enter your wallet password. The funding waits for the network to lock the L1 transaction — usually a few seconds with InstantSend, or a few minutes if it falls back to a ChainLock. If the app is closed meanwhile, the funding can be resumed.
             </Text>
             <div className={"mt-2"}>
               <Input
@@ -265,6 +272,7 @@ export default function AssetLockFundingModal({
                 const current = phaseIndex(state.phase)
                 const done = i < current
                 const active = i === current
+                const label = p.key === 'waitingChainLock' ? lockStepLabel(state, active) : p.label
                 return (
                   <div key={p.key} className={"flex items-center gap-2"}>
                     {done
@@ -272,7 +280,7 @@ export default function AssetLockFundingModal({
                       : active
                         ? <Spinner size={14} className={"text-dash-brand dark:text-dash-mint"} />
                         : <div className={"size-3.5 rounded-full border border-dash-primary-dark-blue/20 dark:border-white/20"} />}
-                    <Text size={14} weight={"medium"} color={"brand"} opacity={active || done ? 100 : 40}>{p.label}</Text>
+                    <Text size={14} weight={"medium"} color={"brand"} opacity={active || done ? 100 : 40}>{label}</Text>
                   </div>
                 )
               })}

--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -198,11 +198,9 @@ export default function AssetLockFundingModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={requestClose}
     >
       <div
         className={"w-full max-w-140 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/DeleteWallet.tsx
+++ b/src/renderer/src/components/modal/DeleteWallet.tsx
@@ -55,8 +55,8 @@ export default function DeleteWallet({isDeleteOpen, setIsDeleteOpen, walletToDel
   return (
     <>
       {isDeleteOpen && createPortal(
-        <div className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center"} onClick={closeDeleteModal}>
-          <div className={"w-full max-w-97.5 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem]"} onClick={(e) => e.stopPropagation()}>
+        <div className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center"}>
+          <div className={"w-full max-w-97.5 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem]"}>
             <div className={"flex items-center justify-between"}>
               <Text size={24} weight={"extrabold"} color={"brand"}>
                 Delete Wallet

--- a/src/renderer/src/components/modal/ExportMnemonic.tsx
+++ b/src/renderer/src/components/modal/ExportMnemonic.tsx
@@ -63,11 +63,9 @@ export default function ExportMnemonic({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={onClose}
     >
       <div
         className={"w-full max-w-115 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/SendConfirmModal.tsx
+++ b/src/renderer/src/components/modal/SendConfirmModal.tsx
@@ -4,11 +4,12 @@ import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon, ExternalLinkIco
 import { CopyIcon2 } from '../dash-ui-kit-enxtended/icons'
 import { useTheme } from 'dash-ui-kit/react'
 import { API } from '@renderer/api'
-import { Network, SendResult } from '@renderer/api/types'
+import { Network, SendResult, TxLockStatus } from '@renderer/api/types'
 import { davToDash } from '@renderer/utils/balance'
 import { transactionUrl, openExternal } from '@renderer/utils/explorer'
 import Spinner from '@renderer/components/ui/Spinner'
 import CopyableError from '@renderer/components/ui/CopyableError'
+import { refreshTransactions } from '@renderer/hooks/useWalletTransactions'
 
 interface SendConfirmModalProps {
   isOpen: boolean
@@ -22,6 +23,19 @@ interface SendConfirmModalProps {
 }
 
 type Phase = 'confirm' | 'sending' | 'done'
+type LockPhase = 'waiting' | 'fallback' | 'instant' | 'chainlocked' | 'confirmed'
+
+const LOCK_POLL_INTERVAL_MS = 2_000
+const FALLBACK_POLL_INTERVAL_MS = 10_000
+const INSTANT_LOCK_FALLBACK_MS = 15_000
+
+const LOCK_PHASE_COPY: Record<LockPhase, string> = {
+  waiting: 'Waiting for InstantSend confirmation…',
+  fallback: 'No InstantSend lock yet — waiting for block confirmation (ChainLock). This can take a few minutes; you can close this window, the transaction list will update.',
+  instant: 'Confirmed by InstantSend — the payment is final.',
+  chainlocked: 'Confirmed by ChainLock — the payment is final.',
+  confirmed: 'Confirmed in a block.',
+}
 
 function TxidField({ txid, network }: { txid: string; network: Network | null }): React.JSX.Element {
   const [copied, setCopied] = useState(false)
@@ -107,6 +121,7 @@ export default function SendConfirmModal({
   const { theme } = useTheme()
   const [password, setPassword] = useState('')
   const [phase, setPhase] = useState<Phase>('confirm')
+  const [lockPhase, setLockPhase] = useState<LockPhase>('waiting')
   const [error, setError] = useState<string | null>(null)
   const [result, setResult] = useState<SendResult | null>(null)
 
@@ -114,14 +129,45 @@ export default function SendConfirmModal({
     if (isOpen) {
       setPassword('')
       setPhase('confirm')
+      setLockPhase('waiting')
       setError(null)
       setResult(null)
     }
   }, [isOpen])
 
+  useEffect(() => {
+    if (!isOpen || phase !== 'done' || !walletId || !result?.txid) return
+    const txid = result.txid
+    let cancelled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const startedAt = Date.now()
+    const poll = async (): Promise<void> => {
+      const status: TxLockStatus | null = await API.getTxLockStatus(walletId, txid).catch(() => null)
+      if (cancelled) return
+      const final: LockPhase | null = status?.instantLocked ? 'instant'
+        : status?.chainlocked ? 'chainlocked'
+        : status?.confirmed ? 'confirmed'
+        : null
+      if (final) {
+        setLockPhase(final)
+        refreshTransactions(walletId)
+        return
+      }
+      const fallback = Date.now() - startedAt >= INSTANT_LOCK_FALLBACK_MS
+      if (fallback) setLockPhase('fallback')
+      timer = setTimeout(poll, fallback ? FALLBACK_POLL_INTERVAL_MS : LOCK_POLL_INTERVAL_MS)
+    }
+    poll()
+    return () => {
+      cancelled = true
+      if (timer) clearTimeout(timer)
+    }
+  }, [isOpen, phase, walletId, result?.txid])
+
   if (!isOpen) return null
 
   const sending = phase === 'sending'
+  const lockFinal = lockPhase !== 'waiting' && lockPhase !== 'fallback'
 
   const handleConfirm = async (): Promise<void> => {
     if (!walletId || password.length === 0 || sending) return
@@ -155,7 +201,9 @@ export default function SendConfirmModal({
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>
-            {phase === 'done' ? 'Transaction sent' : 'Confirm send'}
+            {phase === 'done'
+              ? lockFinal ? 'Transaction confirmed' : 'Transaction sent'
+              : 'Confirm send'}
           </Text>
           <button
             className={"dash-text-default hover:opacity-60 cursor-pointer disabled:opacity-30 disabled:cursor-default"}
@@ -247,9 +295,19 @@ export default function SendConfirmModal({
               <Text size={16} weight={"extrabold"} color={"brand"} className={"mt-3"}>
                 {result ? davToDash(BigInt(result.amount)) : ''} Dash sent
               </Text>
-              <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>
-                Broadcast to the network. It will confirm shortly.
-              </Text>
+              <div className={"mt-2 flex items-center justify-center gap-2"}>
+                {lockFinal
+                  ? <CheckIcon size={14} className={"shrink-0 text-dash-brand dark:text-dash-mint [&_circle]:hidden"} />
+                  : <Spinner size={14} />}
+                <Text
+                  size={12}
+                  weight={"medium"}
+                  color={lockFinal ? 'blue-mint' : 'brand'}
+                  opacity={lockFinal ? 100 : 50}
+                >
+                  {LOCK_PHASE_COPY[lockPhase]}
+                </Text>
+              </div>
             </div>
 
             <div className={"mt-5 flex flex-col gap-[.75rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>

--- a/src/renderer/src/components/modal/SendConfirmModal.tsx
+++ b/src/renderer/src/components/modal/SendConfirmModal.tsx
@@ -193,11 +193,9 @@ export default function SendConfirmModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={requestClose}
     >
       <div
         className={"w-full max-w-105 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/ShieldConfirmModal.tsx
+++ b/src/renderer/src/components/modal/ShieldConfirmModal.tsx
@@ -76,11 +76,9 @@ export default function ShieldConfirmModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={requestClose}
     >
       <div
         className={"w-full max-w-140 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -140,11 +140,9 @@ export default function ShieldedSpendModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={requestClose}
     >
       <div
         className={"w-full max-w-140 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/ShieldedUnlockModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedUnlockModal.tsx
@@ -53,11 +53,9 @@ export default function ShieldedUnlockModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={onClose}
     >
       <div
         className={"w-full max-w-115 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/components/modal/TransferConfirmModal.tsx
+++ b/src/renderer/src/components/modal/TransferConfirmModal.tsx
@@ -76,11 +76,9 @@ export default function TransferConfirmModal({
   return createPortal(
     <div
       className={"fixed inset-0 z-99 bg-black/64 flex items-center justify-center overlay-fade-in"}
-      onClick={requestClose}
     >
       <div
         className={"w-full max-w-140 rounded-3xl bg-white dark:bg-white/12 p-6 dark:backdrop-blur-[2rem] modal-fade-in"}
-        onClick={(e) => e.stopPropagation()}
       >
         <div className={"flex items-center justify-between"}>
           <Text size={24} weight={"extrabold"} color={"brand"}>

--- a/src/renderer/src/hooks/useWalletTransactions.tsx
+++ b/src/renderer/src/hooks/useWalletTransactions.tsx
@@ -58,6 +58,7 @@ function groupTransactionsByDay(items: WalletTxItem[]) {
 
 function mapStatus(status: string, confirmations: number): UiStatus {
   if (status === 'Failed' || status === 'Error') return 'failed'
+  if (status === 'Locked') return 'success'
   if (confirmations >= 6) return 'success'
   return 'pending'
 }


### PR DESCRIPTION


## InstantSend
- All 4 asset-lock funding routes now use `waitForAssetLockProof` (InstantSend lock race, ChainLock fallback). Identity register / top-up; **shield (core → shielded) and Platform address funding (core → platformAddress)** — previously they polled tx height and waited for a ChainLock unconditionally (~2–5 min; now seconds when the quorum issues an islock).
- `broadcastAddressFundingSt` and the shielded worker build `InstantAssetLockProof` from the received islock (`ShieldAssetLockProofParams` union in the main ↔ shielded worker message).

## Bug fixes
- **Funding stuck forever in "Waiting for ChainLock"**: shield/address fundings gated confirmation on the local SPV store (`provider.getTransactionByHash`), which trails the tip by `SCAN_TIP_DEPTH = 10` blocks and had lost the block (below). Confirmation is now network-driven via DAPI.
- **SPV scan lost matched blocks permanently**: `CFilterSyncWorker.requestFullBlock` silently dropped a matched block when no peer was ready at that instant, and the cursor then advanced past it — the tx never landed in the local store. The request is now registered before peer pick and retried on a timer; the retry timer also re-arms when no peers are available.
- `applyBlock` persistence in the main process is retried on transient SQL failures (a lost `blockApplied` is unrecoverable).

## UI
- Funding modal shows live lock status: "Waiting for an InstantSend lock…" → "InstantSend lock received" / "ChainLock received" (`lockKind` in the funding state), poll 3s → 1.5s.
- All modals close only via explicit buttons, no longer on overlay click.

