### PR TITLE
feat: auto-derive core/shielded/platform addresses + periodic balance refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@fontsource/manrope": "^5.2.8",
     "@noble/hashes": "^2.0.1",
     "@scure/base": "^2.0.0",
+    "@scure/bip32": "2.0.1",
     "@scure/bip39": "^2.0.1",
     "class-variance-authority": "0.7.1",
     "classic-level": "^3.0.0",

--- a/src/main/migrations/0014_core_xpub.ts
+++ b/src/main/migrations/0014_core_xpub.ts
@@ -1,0 +1,13 @@
+import type {Knex} from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('wallet', table => {
+    table.text('core_xpub').nullable()
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.alterTable('wallet', table => {
+    table.dropColumn('core_xpub')
+  })
+}

--- a/src/main/migrations/0015_shielded_addresses.ts
+++ b/src/main/migrations/0015_shielded_addresses.ts
@@ -1,0 +1,14 @@
+import type {Knex} from 'knex'
+
+export async function up(knex: Knex): Promise<void> {
+  await knex.schema.createTable('shielded_addresses', table => {
+    table.string('wallet_id').notNullable()
+    table.integer('address_index').notNullable()
+    table.text('address').notNullable()
+    table.primary(['wallet_id', 'address_index'])
+  })
+}
+
+export async function down(knex: Knex): Promise<void> {
+  await knex.schema.dropTable('shielded_addresses')
+}

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -59,6 +59,7 @@ import {SetConnectionTypeHandler} from "./api/setConnectionType";
 import {WalletSyncService} from './services/WalletSyncService'
 import {ShieldedService} from './services/ShieldedService'
 import {ShieldedNoteDAO} from './database/ShieldedNoteDAO'
+import {ShieldedAddressDAO} from './database/ShieldedAddressDAO'
 import {GetShieldedStatusHandler} from './api/shielded/getShieldedStatus'
 import {GetShieldedPoolInfoHandler} from './api/shielded/getShieldedPoolInfo'
 import {StartShieldedSyncHandler} from './api/shielded/startShieldedSync'
@@ -84,6 +85,7 @@ import {GetUtxosHandler} from './api/walletSync/getUtxos'
 import {HasSyncProgressHandler} from './api/walletSync/hasSyncProgress'
 import {BroadcastTransactionHandler} from './api/walletSync/broadcastTransaction'
 
+const DISCOVERY_INTERVAL_MS = 120_000
 
 export class WalletBackend {
   private walletService?: WalletService
@@ -194,9 +196,10 @@ export class WalletBackend {
     this.walletSyncService = new WalletSyncService(walletDAO, addressDAO, transactionDAO)
     this.ratesService = new RatesService()
     this.contactService = new ContactService(contactDAO)
+    const shieldedAddressDAO = new ShieldedAddressDAO(knex)
     this.identityRegistrationService = new IdentityRegistrationService(sdkProvider)
-    this.shieldedService = new ShieldedService(sdkProvider, walletDAO, identityDAO, new ShieldedNoteDAO(knex), this.identityRegistrationService)
-    this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, transactionDAO, this.applicationService, this.walletSyncService, sdkProvider, calibratedIterations)
+    this.shieldedService = new ShieldedService(sdkProvider, walletDAO, identityDAO, new ShieldedNoteDAO(knex), shieldedAddressDAO, this.identityRegistrationService)
+    this.walletService = new WalletService(walletDAO, addressDAO, identityDAO, transactionDAO, this.applicationService, this.walletSyncService, sdkProvider, calibratedIterations, this.shieldedService)
     this.platformAddressService = new PlatformAddressService(walletDAO, identityDAO, sdkProvider, this.shieldedService)
     this.assetLockService = new AssetLockService(walletDAO, identityDAO, new AssetLockDAO(knex), this.walletService, this.shieldedService, sdkProvider, this.identityRegistrationService)
     this.sdkProvider = sdkProvider
@@ -205,6 +208,22 @@ export class WalletBackend {
     this.identityDAO = identityDAO
 
     this.initHandlers()
+
+    const walletService = this.walletService
+    const discoverSelected = async (): Promise<void> => {
+      const selected = await walletDAO.getSelectedWallet()
+      if (selected != null) {
+        await walletService.discoverCoreAddresses(selected.walletId)
+      }
+    }
+    this.walletSyncService.onWalletActivity = (walletId) => {
+      walletService.discoverCoreAddresses(walletId).catch(err =>
+        console.error('[discovery] post-sync address discovery failed:', err))
+    }
+    discoverSelected().catch(err => console.error('[discovery] startup address discovery failed:', err))
+    setInterval(() => {
+      discoverSelected().catch(err => console.error('[discovery] periodic address discovery failed:', err))
+    }, DISCOVERY_INTERVAL_MS).unref()
 
     this.applicationService.markReady()
   }

--- a/src/main/src/api/wallet/selectWallet.ts
+++ b/src/main/src/api/wallet/selectWallet.ts
@@ -10,6 +10,11 @@ export class SelectWallet {
   }
 
   handle = async (_event: IpcMainInvokeEvent, walletId: string): Promise<QueryStatus> => {
-    return this.walletService.setSelectedWallet(walletId)
+    const result = await this.walletService.setSelectedWallet(walletId)
+    if (result.success) {
+      this.walletService.discoverCoreAddresses(walletId).catch(err =>
+        console.error('[discovery] address discovery on wallet select failed:', err))
+    }
+    return result
   }
 }

--- a/src/main/src/database/AddressDAO.ts
+++ b/src/main/src/database/AddressDAO.ts
@@ -60,6 +60,14 @@ export class AddressDAO {
     }, {receiving: [], change: []})
   }
 
+  markAddressesUsed = async (walletId: string, addresses: string[]): Promise<void> => {
+    if (addresses.length === 0) return
+    await this.knex('addresses')
+      .where('wallet_id', walletId)
+      .whereIn('address', addresses)
+      .update({is_used: true})
+  }
+
   setAddressLabel = async (walletId: string, address: string, label: string): Promise<QueryStatus> => {
     const result = await this.knex('addresses')
       .where('address', address)

--- a/src/main/src/database/ShieldedAddressDAO.ts
+++ b/src/main/src/database/ShieldedAddressDAO.ts
@@ -1,0 +1,29 @@
+import type {Knex} from 'knex'
+
+export class ShieldedAddressDAO {
+  knex: Knex
+
+  constructor(knex: Knex) {
+    this.knex = knex
+  }
+
+  getAddresses = async (walletId: string): Promise<string[]> => {
+    const rows = await this.knex('shielded_addresses')
+      .select('address')
+      .where('wallet_id', walletId)
+      .orderBy('address_index', 'asc')
+    return rows.map(row => row.address)
+  }
+
+  saveAddresses = async (walletId: string, addresses: string[]): Promise<void> => {
+    if (addresses.length === 0) return
+    await this.knex('shielded_addresses')
+      .insert(addresses.map((address, index) => ({
+        wallet_id: walletId,
+        address_index: index,
+        address,
+      })))
+      .onConflict(['wallet_id', 'address_index'])
+      .merge({address: this.knex.raw('excluded.address')})
+  }
+}

--- a/src/main/src/database/WalletDAO.ts
+++ b/src/main/src/database/WalletDAO.ts
@@ -1,8 +1,8 @@
 import {Wallet} from '../types/Wallet'
 import {QueryStatus} from "../types/QueryStatus";
 
-function fromRow({wallet_id, label, network, encrypted_mnemonic, selected, platform_xpub}): Wallet {
-  return {walletId: wallet_id, network, label, encryptedMnemonic: encrypted_mnemonic, selected: Boolean(selected), platformXpub: platform_xpub ?? null}
+function fromRow({wallet_id, label, network, encrypted_mnemonic, selected, platform_xpub, core_xpub}): Wallet {
+  return {walletId: wallet_id, network, label, encryptedMnemonic: encrypted_mnemonic, selected: Boolean(selected), platformXpub: platform_xpub ?? null, coreXpub: core_xpub ?? null}
 }
 
 export class WalletDAO {
@@ -44,7 +44,7 @@ export class WalletDAO {
 
   getWalletById = async (walletId): Promise<Wallet | null> => {
     const rows = await this.knex('wallet')
-      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub')
+      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub', 'core_xpub')
       .where('wallet_id', walletId)
       .limit(1)
 
@@ -59,14 +59,14 @@ export class WalletDAO {
 
   getAllWallets = async (): Promise<Wallet[]> => {
     const rows = await this.knex('wallet')
-      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub')
+      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub', 'core_xpub')
 
     return rows.map(fromRow)
   }
 
   getSelectedWallet = async (): Promise<Wallet | null> => {
     const rows = await this.knex('wallet')
-      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub')
+      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub', 'core_xpub')
       .where('selected', true)
       .limit(1)
 
@@ -143,6 +143,12 @@ export class WalletDAO {
       .where('wallet_id', walletId)
   }
 
+  setCoreXpub = async (walletId: string, coreXpub: string): Promise<void> => {
+    await this.knex('wallet')
+      .update({core_xpub: coreXpub})
+      .where('wallet_id', walletId)
+  }
+
   updateLabel = async (walletId: string, label: string | null): Promise<QueryStatus> => {
     try {
       const result = await this.knex('wallet')
@@ -172,7 +178,7 @@ export class WalletDAO {
 
   getWalletsByNetwork = async (network): Promise<Wallet[]> => {
     const rows = await this.knex('wallet')
-      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub')
+      .select('encrypted_mnemonic', 'network', 'wallet_id', 'label', 'selected', 'platform_xpub', 'core_xpub')
       .where('network', network)
 
     return rows.map(fromRow)

--- a/src/main/src/providers/InsightWalletProvider.ts
+++ b/src/main/src/providers/InsightWalletProvider.ts
@@ -125,13 +125,31 @@ export class InsightWalletProvider implements WalletProvider {
     }
   }
 
-  // TODO: walk receiving addresses and return the first one with no on-chain
-  // history via the Insight API. For the first release we just return the
-  // first receiving address.
   async nextUnusedAddress(): Promise<string> {
     const { receiving } = await this.addressDAO.getAddressesByWalletId(this.walletId)
     if (receiving.length === 0) throw new Error('Wallet has no receiving addresses')
-    return receiving[0].address
+    const unused = receiving.find(a => !a.isUsed)
+    return (unused ?? receiving[receiving.length - 1]).address
+  }
+
+  async getUsedAddresses(addresses: string[]): Promise<string[]> {
+    if (addresses.length === 0) return []
+
+    const probe = await this.sendRequest(`${this.baseUrl}/addrs/txs`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({addrs: addresses.join(','), from: 0, to: 1})
+    })
+    const {totalItems} = await probe.json() as { totalItems: number }
+    if (!totalItems) return []
+
+    const flags = await Promise.all(addresses.map(async (address) => {
+      const response = await this.sendRequest(`${this.baseUrl}/addr/${address}?noTxList=1`)
+      const info = await response.json() as { txApperances?: number; unconfirmedTxApperances?: number }
+      return (info.txApperances ?? 0) + (info.unconfirmedTxApperances ?? 0) > 0
+    }))
+
+    return addresses.filter((_, i) => flags[i])
   }
 
   private async allWalletAddresses() {

--- a/src/main/src/providers/InsightWalletProvider.ts
+++ b/src/main/src/providers/InsightWalletProvider.ts
@@ -14,6 +14,8 @@ const BASE_URLS: Record<Network, string> = {
   testnet: 'https://insight.testnet.networks.dash.org/insight-api'
 }
 
+const BALANCE_ADDRESS_CHUNK = 25
+
 export interface InsightUTXO {
   txid: string
   vout: number
@@ -56,14 +58,24 @@ export class InsightWalletProvider implements WalletProvider {
   }
 
   async getBalance(address: string | string[]): Promise<bigint> {
-    const endpoint = Array.isArray(address) ? 'addrs' : 'addr'
-    const parameter = Array.isArray(address) ? address.join(',') : address
+    if (!Array.isArray(address)) {
+      const response = await this.sendRequest(`${this.baseUrl}/addr/${address}/balance`)
+      return BigInt(await response.text())
+    }
 
-    const response = await this.sendRequest(`${this.baseUrl}/${endpoint}/${parameter}/balance`)
+    if (address.length === 0) return 0n
 
-    const data = await response.text()
+    const chunks: string[][] = []
+    for (let i = 0; i < address.length; i += BALANCE_ADDRESS_CHUNK) {
+      chunks.push(address.slice(i, i + BALANCE_ADDRESS_CHUNK))
+    }
 
-    return BigInt(data)
+    const balances = await Promise.all(chunks.map(async (chunk) => {
+      const response = await this.sendRequest(`${this.baseUrl}/addrs/${chunk.join(',')}/balance`)
+      return BigInt(await response.text())
+    }))
+
+    return balances.reduce((acc, value) => acc + value, 0n)
   }
 
   async getTransactionByHash(txId: string): Promise<Transaction> {

--- a/src/main/src/providers/P2PWalletProvider.ts
+++ b/src/main/src/providers/P2PWalletProvider.ts
@@ -82,6 +82,10 @@ export class P2PWalletProvider implements WalletProvider {
     return receiving[receiving.length - 1].address
   }
 
+  async getUsedAddresses(): Promise<string[]> {
+    return []
+  }
+
   private p2pkhScript(address: string): Script {
     const s = new Script()
     s.pushOpCode('OP_DUP')

--- a/src/main/src/providers/WalletProvider.ts
+++ b/src/main/src/providers/WalletProvider.ts
@@ -15,8 +15,7 @@ export interface WalletProvider {
   // Returns the next unused receiving address for the wallet — used by the
   // Receive tab and change-output selection. The provider decides what
   // "unused" means against its source of truth (chain state via API,
-  // local SPV-synced DB, etc.). For the first release this is simplified
-  // to "the first receiving address"; full chain-history iteration is a
-  // follow-up.
+  // local SPV-synced DB, etc.).
   nextUnusedAddress(): Promise<string>
+  getUsedAddresses(addresses: string[]): Promise<string[]>
 }

--- a/src/main/src/services/PlatformAddressService.ts
+++ b/src/main/src/services/PlatformAddressService.ts
@@ -44,6 +44,7 @@ import {
 const PLATFORM_ACCOUNT = 0
 const PLATFORM_ADDRESS_LOOKAHEAD = 20
 const IDENTITY_KEY_LOOKAHEAD = 20
+const MAX_DISCOVERY_BATCHES = 50
 const COIN_TYPE: Record<Network, number> = {mainnet: 5, testnet: 1}
 
 // Platform (L2) addresses follow DIP-17: m/9'/coinType'/17'/account'/0'/index.
@@ -72,6 +73,8 @@ export class PlatformAddressService {
     if (wallet.platformXpub == null) {
       return []
     }
+
+    await this.extendPlatformWindow(walletId, wallet.platformXpub, wallet.network)
 
     const candidates = await this.loadPlatformCandidates(walletId, wallet.platformXpub, wallet.network)
     return candidates.map(candidate => ({
@@ -607,6 +610,37 @@ export class PlatformAddressService {
     }
 
     return {wallet, seed, xpub}
+  }
+
+  private async extendPlatformWindow(walletId: string, xpub: string, network: Network): Promise<void> {
+    const stored = await this.walletDAO.getPlatformAddressCount(walletId)
+    const windowEnd = Math.max(PLATFORM_ADDRESS_LOOKAHEAD, stored)
+    let probeStart = windowEnd
+    let lastUsed = -1
+
+    for (let batch = 0; batch < MAX_DISCOVERY_BATCHES; batch++) {
+      const addresses: string[] = []
+      for (let index = probeStart; index < probeStart + PLATFORM_ADDRESS_LOOKAHEAD; index++) {
+        addresses.push(this.platformSDK(network).keyPair.derivePlatformAddressFromXpub(xpub, network, index).toBech32m(network))
+      }
+      const infos = await this.fetchPlatformAddressInfos(addresses, network)
+
+      let usedInBatch = -1
+      addresses.forEach((address, i) => {
+        const info = infos.get(address)
+        if (info != null && (info.balance > 0n || info.nonce > 0)) {
+          usedInBatch = probeStart + i
+        }
+      })
+      if (usedInBatch === -1) break
+
+      lastUsed = usedInBatch
+      probeStart += PLATFORM_ADDRESS_LOOKAHEAD
+    }
+
+    if (lastUsed >= windowEnd) {
+      await this.walletDAO.setPlatformAddressCount(walletId, lastUsed + 1)
+    }
   }
 
   private async loadPlatformCandidates(walletId: string, xpub: string, network: Network): Promise<PlatformSourceCandidate[]> {

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -7,6 +7,7 @@ import { Network } from '../types'
 import { WalletDAO } from '../database/WalletDAO'
 import { IdentityDAO } from '../database/IdentityDAO'
 import { ShieldedNoteDAO } from '../database/ShieldedNoteDAO'
+import { ShieldedAddressDAO } from '../database/ShieldedAddressDAO'
 import { decryptMnemonic } from '../utils'
 import {
   ShieldAssetLockProofParams,
@@ -75,6 +76,7 @@ export class ShieldedService {
   private walletDAO: WalletDAO
   private identityDAO: IdentityDAO
   private shieldedNoteDAO: ShieldedNoteDAO
+  private shieldedAddressDAO: ShieldedAddressDAO
   private identityRegistrationService: IdentityRegistrationService
   private child: UtilityProcess | null = null
   private childOutputTail = ''
@@ -88,11 +90,12 @@ export class ShieldedService {
   private pendingIdentityCreates = new Map<string, {walletId: string; identityIndex: number; network: Network}>()
   private pendingShields = new Map<string, {resolve: (stHash: string) => void; reject: (error: Error) => void}>()
 
-  constructor(sdkProvider: SdkProvider, walletDAO: WalletDAO, identityDAO: IdentityDAO, shieldedNoteDAO: ShieldedNoteDAO, identityRegistrationService: IdentityRegistrationService) {
+  constructor(sdkProvider: SdkProvider, walletDAO: WalletDAO, identityDAO: IdentityDAO, shieldedNoteDAO: ShieldedNoteDAO, shieldedAddressDAO: ShieldedAddressDAO, identityRegistrationService: IdentityRegistrationService) {
     this.sdkProvider = sdkProvider
     this.walletDAO = walletDAO
     this.identityDAO = identityDAO
     this.shieldedNoteDAO = shieldedNoteDAO
+    this.shieldedAddressDAO = shieldedAddressDAO
     this.identityRegistrationService = identityRegistrationService
   }
 
@@ -282,10 +285,21 @@ export class ShieldedService {
   async getAddresses(walletId: string, password?: string): Promise<string[] | null> {
     const cached = this.addresses.get(walletId)
     if (cached != null) return cached
+
+    const persisted = await this.shieldedAddressDAO.getAddresses(walletId)
+    if (persisted.length > 0) {
+      this.addresses.set(walletId, persisted)
+      return persisted
+    }
+
     if (password == null || password.length === 0) return null
 
     const {seed, network} = await this.unlock(walletId, password)
     return this.cacheAddresses(walletId, seed, network)
+  }
+
+  async initAddresses(walletId: string, seed: Uint8Array, network: Network): Promise<void> {
+    await this.cacheAddresses(walletId, seed, network)
   }
 
   async addAddress(walletId: string, password: string): Promise<string[]> {
@@ -305,6 +319,7 @@ export class ShieldedService {
       list.push(this.sdkProvider.getPlatformSDK(network).keyPair.deriveShieldedAddress(seed, network, SHIELDED_ACCOUNT, i).toBech32m(network))
     }
     this.addresses.set(walletId, list)
+    await this.shieldedAddressDAO.saveAddresses(walletId, list)
     return list
   }
 

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -26,9 +26,12 @@ import {selectCoins, SelectableUtxo} from "../utils/coinSelection";
 import {dedupeTransactions} from "../utils/dedupeTransactions";
 import {CoreTransactionService, TransferInput} from "./CoreTransactionService";
 import {decryptMnemonic, encryptMnemonic} from "../utils";
+import {coreAccountPath, deriveCorePublicKey, planGapExtension} from "../utils/addressDiscovery";
+import {ShieldedService} from "./ShieldedService";
 
 const ADDRESS_LOOKAHEAD = 20
 const IDENTITY_LOOKAHEAD = 10
+const MAX_DISCOVERY_ROUNDS = 10
 const COIN_TYPE: Record<Network, number> = {mainnet: 5, testnet: 1}
 const PLATFORM_ACCOUNT = 0
 
@@ -42,6 +45,8 @@ export class WalletService {
   private sdkProvider: SdkProvider
   private pbkdf2Iterations: number
   private coreTransactionService: CoreTransactionService
+  private shieldedService: ShieldedService
+  private discoveryInflight = new Map<string, Promise<void>>()
 
   constructor(
     walletDAO: WalletDAO,
@@ -52,6 +57,7 @@ export class WalletService {
     walletSyncService: WalletSyncService,
     sdkProvider: SdkProvider,
     pbkdf2Iterations: number,
+    shieldedService: ShieldedService,
   ) {
     this.pbkdf2Iterations = pbkdf2Iterations
     this.walletDAO = walletDAO
@@ -62,6 +68,7 @@ export class WalletService {
     this.walletSyncService = walletSyncService
     this.sdkProvider = sdkProvider
     this.coreTransactionService = new CoreTransactionService(sdkProvider)
+    this.shieldedService = shieldedService
   }
 
   // Picks the WalletProvider for a wallet at call time, honouring the user's
@@ -99,6 +106,9 @@ export class WalletService {
     const platformXpub = await sdk.keyPair.derivePlatformAccountXpub(seed, network, PLATFORM_ACCOUNT)
     await this.walletDAO.setPlatformXpub(walletId, platformXpub)
 
+    const coreAccountNode = await sdk.keyPair.derivePath(hdKey, coreAccountPath(coinType, accountId))
+    await this.walletDAO.setCoreXpub(walletId, coreAccountNode.publicExtendedKey)
+
     const addresses: Address[] = []
 
     for (let i = 0; i < ADDRESS_LOOKAHEAD; i++) {
@@ -135,9 +145,17 @@ export class WalletService {
 
     await this.addressDAO.insertAddresses(addresses)
 
+    try {
+      await this.discoverCoreAddresses(walletId)
+    } catch (e) {
+      console.error('Core address discovery after wallet creation failed:', e)
+    }
+
+    await this.shieldedService.initAddresses(walletId, seed, network)
+
     const identities: Identity[] = []
 
-    for (let i = 0; i < IDENTITY_LOOKAHEAD; i++) {
+    for (let i = 0, gap = 0; gap < IDENTITY_LOOKAHEAD; i++) {
       const key = sdk.keyPair.deriveIdentityPrivateKey(hdKey, i, 0, network)
       if (!key.publicKey) throw new Error(`Failed to derive identity public key at index ${i}`)
 
@@ -168,6 +186,9 @@ export class WalletService {
           derivationPath: `m/9'/${coinType}'/0'/0/${i}`,
           identifier
         })
+        gap = 0
+      } else {
+        gap++
       }
     }
 
@@ -247,6 +268,11 @@ export class WalletService {
       await this.walletDAO.setPlatformXpub(walletId, platformXpub)
     }
 
+    if (isValid && wallet.coreXpub == null) {
+      const accountNode = await keyPair.derivePath(hdKey, coreAccountPath(coinType, 0))
+      await this.walletDAO.setCoreXpub(walletId, accountNode.publicExtendedKey)
+    }
+
     return isValid
   }
 
@@ -295,7 +321,66 @@ export class WalletService {
       label: null
     }])
 
+    await this.walletSyncService.addWatchAddresses(walletId, [address])
+
     return address
+  }
+
+  discoverCoreAddresses(walletId: string): Promise<void> {
+    const existing = this.discoveryInflight.get(walletId)
+    if (existing) return existing
+    const run = this.runCoreDiscovery(walletId).finally(() => this.discoveryInflight.delete(walletId))
+    this.discoveryInflight.set(walletId, run)
+    return run
+  }
+
+  private async runCoreDiscovery(walletId: string): Promise<void> {
+    const wallet = await this.walletDAO.getWalletById(walletId)
+    if (wallet == null || wallet.coreXpub == null) return
+
+    const coreXpub = wallet.coreXpub
+    const network = wallet.network
+    const provider = this.getProvider(walletId, network)
+    const sdk = this.sdkProvider.getPlatformSDK(network)
+    const coinType = COIN_TYPE[network]
+    const added: string[] = []
+
+    for (const isChange of [false, true]) {
+      for (let round = 0; round < MAX_DISCOVERY_ROUNDS; round++) {
+        const grouped = await this.addressDAO.getAddressesByWalletId(walletId)
+        const chain = isChange ? grouped.change : grouped.receiving
+        const unused = chain.filter(a => !a.isUsed)
+        const newlyUsed = unused.length > 0 ? await provider.getUsedAddresses(unused.map(a => a.address)) : []
+        if (newlyUsed.length > 0) {
+          await this.addressDAO.markAddressesUsed(walletId, newlyUsed)
+        }
+
+        const usedSet = new Set(newlyUsed)
+        const entries = chain.map(a => ({index: a.index, isUsed: a.isUsed || usedSet.has(a.address)}))
+        const indexes = planGapExtension(entries, ADDRESS_LOOKAHEAD)
+        if (indexes.length === 0) break
+
+        const rows: Address[] = indexes.map(index => {
+          const publicKey = deriveCorePublicKey(coreXpub, network, isChange, index)
+          return {
+            walletId,
+            accountId: 0,
+            address: sdk.keyPair.p2pkhAddress(publicKey, network),
+            derivationPath: `m/44'/${coinType}'/0'/${isChange ? 1 : 0}/${index}`,
+            index,
+            isChange,
+            isUsed: false,
+            label: null
+          }
+        })
+        await this.addressDAO.insertAddresses(rows)
+        added.push(...rows.map(r => r.address))
+      }
+    }
+
+    if (added.length > 0) {
+      await this.walletSyncService.addWatchAddresses(walletId, added)
+    }
   }
 
   async getReceiveAddress(walletId: string): Promise<string> {

--- a/src/main/src/services/WalletSyncService.ts
+++ b/src/main/src/services/WalletSyncService.ts
@@ -68,6 +68,8 @@ export class WalletSyncService {
   // process echoes the requestId back in P2PBroadcastResultMessage so we
   // can resolve the right promise when multiple broadcasts overlap.
   private pendingBroadcasts = new Map<string, (event: {ok: boolean; result: BroadcastResult; errorMessage: string | null}) => void>()
+  onWalletActivity: ((walletId: string) => void) | null = null
+  private activityDebounce: ReturnType<typeof setTimeout> | null = null
 
   constructor(walletDAO: WalletDAO, addressDAO: AddressDAO, transactionDAO: TransactionDAO) {
     this.walletDAO = walletDAO
@@ -263,13 +265,24 @@ export class WalletSyncService {
   }
 
   private persistAppliedBlock = (block: AppliedBlock, attempt = 0): void => {
-    this.transactionDAO.applyBlock(block).catch(err => {
+    this.transactionDAO.applyBlock(block).then(() => {
+      if (block.txs.length > 0) this.notifyWalletActivity(block.walletId)
+    }).catch(err => {
       if (attempt < 2) {
         setTimeout(() => this.persistAppliedBlock(block, attempt + 1), 1_000)
       } else {
         console.error(`[walletSync] applyBlock failed permanently at h=${block.height}:`, err)
       }
     })
+  }
+
+  private notifyWalletActivity(walletId: string): void {
+    if (this.onWalletActivity == null || this.activityDebounce != null) return
+    this.activityDebounce = setTimeout(() => {
+      this.activityDebounce = null
+      this.onWalletActivity?.(walletId)
+    }, 3_000)
+    this.activityDebounce.unref?.()
   }
 
   hasSyncProgress = async (walletId: string): Promise<boolean> => {

--- a/src/main/src/types/Wallet.ts
+++ b/src/main/src/types/Wallet.ts
@@ -7,4 +7,5 @@ export interface Wallet {
   encryptedMnemonic: string
   selected: boolean
   platformXpub: string | null
+  coreXpub: string | null
 }

--- a/src/main/src/utils/addressDiscovery.ts
+++ b/src/main/src/utils/addressDiscovery.ts
@@ -1,0 +1,37 @@
+import {HDKey} from '@scure/bip32'
+import {Network} from '../types'
+
+const HD_VERSIONS: Record<Network, {private: number; public: number}> = {
+  mainnet: {private: 0x0488ade4, public: 0x0488b21e},
+  testnet: {private: 0x04358394, public: 0x043587cf},
+}
+
+export interface GapEntry {
+  index: number
+  isUsed: boolean
+}
+
+export function planGapExtension(entries: GapEntry[], gapLimit: number): number[] {
+  let lastUsed = -1
+  let maxIndex = -1
+  for (const entry of entries) {
+    if (entry.index > maxIndex) maxIndex = entry.index
+    if (entry.isUsed && entry.index > lastUsed) lastUsed = entry.index
+  }
+  const indexes: number[] = []
+  for (let i = maxIndex + 1; i <= lastUsed + gapLimit; i++) indexes.push(i)
+  return indexes
+}
+
+export function coreAccountPath(coinType: number, accountId: number): string {
+  return `m/44'/${coinType}'/${accountId}'`
+}
+
+export function deriveCorePublicKey(coreXpub: string, network: Network, isChange: boolean, index: number): Uint8Array {
+  const accountNode = HDKey.fromExtendedKey(coreXpub, HD_VERSIONS[network])
+  const child = accountNode.deriveChild(isChange ? 1 : 0).deriveChild(index)
+  if (child.publicKey == null) {
+    throw new Error(`Could not derive core public key at index ${index}`)
+  }
+  return child.publicKey
+}

--- a/src/main/src/utils/index.ts
+++ b/src/main/src/utils/index.ts
@@ -17,6 +17,8 @@ import * as migration0010 from '../../migrations/0010_asset_lock_funding_kind'
 import * as migration0011 from '../../migrations/0011_identity_asset_lock'
 import * as migration0012 from '../../migrations/0012_asset_lock_identity_funding'
 import * as migration0013 from '../../migrations/0013_platform_address_count'
+import * as migration0014 from '../../migrations/0014_core_xpub'
+import * as migration0015 from '../../migrations/0015_shielded_addresses'
 
 const migrations = [
   { name: '0000_init.ts', migration: migration0000 },
@@ -33,6 +35,8 @@ const migrations = [
   { name: '0011_identity_asset_lock.ts', migration: migration0011 },
   { name: '0012_asset_lock_identity_funding.ts', migration: migration0012 },
   { name: '0013_platform_address_count.ts', migration: migration0013 },
+  { name: '0014_core_xpub.ts', migration: migration0014 },
+  { name: '0015_shielded_addresses.ts', migration: migration0015 },
 ]
 
 const inlineMigrationSource = {

--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -194,7 +194,7 @@ export default function AssetLockFundingModal({
     onClose()
   }
 
-  const isDone = state?.phase === 'done'
+  const isDone = started && state?.phase === 'done'
   const isError = started && (state?.phase === 'error' || state?.phase === 'resumable')
   const texts = TEXTS[kind]
   const phases = PHASE_LABELS[kind]

--- a/src/renderer/src/components/pages/addresses/AddAddressSection.tsx
+++ b/src/renderer/src/components/pages/addresses/AddAddressSection.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Button, Input, Text } from '@renderer/components/dash-ui-kit-enxtended'
 import { API } from '@renderer/api'
 import { invalidateAsyncCache } from '@renderer/hooks/useAsyncWithCache'
+import { refreshBalance } from '@renderer/hooks/useWalletBalance'
 
 export default function AddAddressSection({ walletId, kind }: { walletId: string | undefined, kind: 'receiving' | 'change' | 'platform' }): React.JSX.Element {
   const [password, setPassword] = useState('')
@@ -16,6 +17,7 @@ export default function AddAddressSection({ walletId, kind }: { walletId: string
     try {
       await API.addPlatformAddress(walletId)
       invalidateAsyncCache('platformAddresses', walletId)
+      refreshBalance(walletId)
     } catch {
       setError('Could not derive a new platform address. Please try again.')
     } finally {
@@ -35,6 +37,7 @@ export default function AddAddressSection({ walletId, kind }: { walletId: string
       }
       await API.addWalletAddress(walletId, password, kind === 'change')
       invalidateAsyncCache('addresses', walletId)
+      refreshBalance(walletId)
       setPassword('')
       setShowForm(false)
     } catch {

--- a/src/renderer/src/components/pages/addresses/ShieldedAddressTab.tsx
+++ b/src/renderer/src/components/pages/addresses/ShieldedAddressTab.tsx
@@ -72,6 +72,9 @@ export default function ShieldedAddressTab({ walletId }: { walletId: string | un
 
   const handleReveal = (): Promise<void> => withPassword(async (pwd) => {
     setAddresses(await API.getShieldedAddresses(walletId!, pwd))
+    if (!synced && !syncRunning) {
+      API.startShieldedSync(walletId!, pwd).catch(() => {})
+    }
   })
 
   const handleConfirmAdd = (): Promise<void> => withPassword(async (pwd) => {

--- a/src/renderer/src/hooks/useAsyncWithCache.ts
+++ b/src/renderer/src/hooks/useAsyncWithCache.ts
@@ -2,16 +2,22 @@ import { useEffect, useRef, useState } from 'react'
 
 const cache = new Map<string, unknown>()
 const inflight = new Map<string, Promise<unknown>>()
-const invalidationListeners = new Map<string, Set<() => void>>()
+const listeners = new Map<string, Set<() => void>>()
+const refreshTimers = new Map<string, { timer: ReturnType<typeof setInterval>; count: number }>()
 
-function subscribeInvalidation(cacheKey: string, listener: () => void): () => void {
-  const set = invalidationListeners.get(cacheKey) ?? new Set()
+function subscribe(cacheKey: string, listener: () => void): () => void {
+  const set = listeners.get(cacheKey) ?? new Set()
   set.add(listener)
-  invalidationListeners.set(cacheKey, set)
+  listeners.set(cacheKey, set)
   return () => {
     set.delete(listener)
-    if (set.size === 0) invalidationListeners.delete(cacheKey)
+    if (set.size === 0) listeners.delete(cacheKey)
   }
+}
+
+function notify(cacheKey: string): void {
+  const set = listeners.get(cacheKey)
+  if (set) for (const listener of [...set]) listener()
 }
 
 function runFetch<T>(cacheKey: string, fetcher: () => Promise<T>): Promise<T> {
@@ -21,6 +27,7 @@ function runFetch<T>(cacheKey: string, fetcher: () => Promise<T>): Promise<T> {
   const p = fetcher()
     .then((result) => {
       cache.set(cacheKey, result)
+      notify(cacheKey)
       return result
     })
     .finally(() => {
@@ -31,8 +38,32 @@ function runFetch<T>(cacheKey: string, fetcher: () => Promise<T>): Promise<T> {
   return p
 }
 
+function retainRefreshTimer(cacheKey: string, intervalMs: number, fetcher: () => Promise<unknown>): () => void {
+  let entry = refreshTimers.get(cacheKey)
+  if (!entry) {
+    entry = {
+      timer: setInterval(() => {
+        runFetch(cacheKey, fetcher).catch(() => {})
+      }, intervalMs),
+      count: 0
+    }
+    refreshTimers.set(cacheKey, entry)
+  }
+  entry.count++
+  return () => {
+    const current = refreshTimers.get(cacheKey)
+    if (!current) return
+    current.count--
+    if (current.count <= 0) {
+      clearInterval(current.timer)
+      refreshTimers.delete(cacheKey)
+    }
+  }
+}
+
 export interface UseAsyncWithCacheOptions {
   errorMessage?: string
+  refreshIntervalMs?: number
 }
 
 export function useAsyncWithCache<T>(
@@ -54,8 +85,23 @@ export function useAsyncWithCache<T>(
 
   useEffect(() => {
     if (cacheKey === undefined) return
-    return subscribeInvalidation(cacheKey, () => setRefetchTick((t) => t + 1))
+    return subscribe(cacheKey, () => {
+      const cached = cache.get(cacheKey) as T | undefined
+      if (cached !== undefined) {
+        setData(cached)
+        setLoading(false)
+        setErr(null)
+      } else {
+        setRefetchTick((t) => t + 1)
+      }
+    })
   }, [cacheKey])
+
+  const refreshIntervalMs = options?.refreshIntervalMs
+  useEffect(() => {
+    if (cacheKey === undefined || refreshIntervalMs === undefined) return
+    return retainRefreshTimer(cacheKey, refreshIntervalMs, () => fetcherRef.current())
+  }, [cacheKey, refreshIntervalMs])
 
   useEffect(() => {
     if (cacheKey === undefined) {
@@ -108,8 +154,7 @@ export function useAsyncWithCache<T>(
 export function invalidateAsyncCache(namespace: string, key: string): void {
   const cacheKey = `${namespace}:${key}`
   cache.delete(cacheKey)
-  const listeners = invalidationListeners.get(cacheKey)
-  if (listeners) for (const listener of [...listeners]) listener()
+  notify(cacheKey)
 }
 
 export function prefetchAsyncCache<T>(

--- a/src/renderer/src/hooks/useWalletBalance.ts
+++ b/src/renderer/src/hooks/useWalletBalance.ts
@@ -26,7 +26,7 @@ export function useWalletBalance(walletId: string | undefined) {
     walletId,
     () => fetchBalance(walletId!),
     initial,
-    { errorMessage: 'Failed to load balance' }
+    { errorMessage: 'Failed to load balance', refreshIntervalMs: 30_000 }
   )
   return { balance: data, loading, err }
 }

--- a/tests/unit/addressDiscovery.test.ts
+++ b/tests/unit/addressDiscovery.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { HDKey } from '@scure/bip32'
+import { mnemonicToSeedSync } from '@scure/bip39'
+import { coreAccountPath, deriveCorePublicKey, planGapExtension } from '../../src/main/src/utils/addressDiscovery'
+
+const GAP = 20
+
+function entries(used: number[], count: number) {
+  const usedSet = new Set(used)
+  return Array.from({ length: count }, (_, index) => ({ index, isUsed: usedSet.has(index) }))
+}
+
+describe('planGapExtension', () => {
+  it('returns nothing for a fresh chain with a full unused gap', () => {
+    expect(planGapExtension(entries([], 20), GAP)).toEqual([])
+  })
+
+  it('seeds a full window for an empty chain', () => {
+    expect(planGapExtension([], GAP)).toEqual(
+      Array.from({ length: 20 }, (_, i) => i),
+    )
+  })
+
+  it('extends up to lastUsed + gap when a tail address is used', () => {
+    expect(planGapExtension(entries([19], 20), GAP)).toEqual(
+      Array.from({ length: 20 }, (_, i) => 20 + i),
+    )
+  })
+
+  it('extends partially when usage sits mid-chain', () => {
+    expect(planGapExtension(entries([5], 20), GAP)).toEqual([20, 21, 22, 23, 24, 25])
+  })
+
+  it('keeps the gap after repeated extensions', () => {
+    const chain = entries([5, 25], 26)
+    expect(planGapExtension(chain, GAP)).toEqual(
+      Array.from({ length: 20 }, (_, i) => 26 + i),
+    )
+  })
+
+  it('handles unordered entries', () => {
+    const shuffled = [...entries([19], 20)].reverse()
+    expect(planGapExtension(shuffled, GAP)).toHaveLength(20)
+  })
+})
+
+describe('deriveCorePublicKey', () => {
+  const versions = {
+    mainnet: { private: 0x0488ade4, public: 0x0488b21e },
+    testnet: { private: 0x04358394, public: 0x043587cf },
+  } as const
+
+  const seed = mnemonicToSeedSync('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about')
+
+  it.each(['mainnet', 'testnet'] as const)('reproduces seed-path public keys on %s', (network) => {
+    const coinType = network === 'mainnet' ? 5 : 1
+    const master = HDKey.fromMasterSeed(seed, versions[network])
+    const accountNode = master.derive(coreAccountPath(coinType, 0))
+    const xpub = accountNode.publicExtendedKey
+
+    for (const isChange of [false, true]) {
+      for (const index of [0, 1, 19, 45]) {
+        const fromSeed = master.derive(`${coreAccountPath(coinType, 0)}/${isChange ? 1 : 0}/${index}`).publicKey
+        const fromXpub = deriveCorePublicKey(xpub, network, isChange, index)
+        expect(Buffer.from(fromXpub).toString('hex')).toBe(Buffer.from(fromSeed!).toString('hex'))
+      }
+    }
+  })
+
+  it('derives distinct keys per chain and index', () => {
+    const master = HDKey.fromMasterSeed(seed, versions.testnet)
+    const xpub = master.derive(coreAccountPath(1, 0)).publicExtendedKey
+    const keys = [
+      deriveCorePublicKey(xpub, 'testnet', false, 0),
+      deriveCorePublicKey(xpub, 'testnet', false, 1),
+      deriveCorePublicKey(xpub, 'testnet', true, 0),
+    ].map(k => Buffer.from(k).toString('hex'))
+    expect(new Set(keys).size).toBe(3)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,9 +1754,9 @@
   resolved "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz"
   integrity sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==
 
-"@scure/bip32@^2.0.0":
+"@scure/bip32@2.0.1", "@scure/bip32@^2.0.0":
   version "2.0.1"
-  resolved "https://registry.npmjs.org/@scure/bip32/-/bip32-2.0.1.tgz"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-2.0.1.tgz#4ceea207cee8626d3fe8f0b6ab68b6af8f81c482"
   integrity sha512-4Md1NI5BzoVP+bhyJaY3K6yMesEFzNS1sE/cP+9nuvE7p/b0kx9XbpDHHFl8dHtufcbdHRUUQdRqLIPHN/s7yA==
   dependencies:
     "@noble/curves" "2.0.1"


### PR DESCRIPTION
Automatic address derivation/discovery so balances and receive addresses stay complete without manual reveal.

## Features
- **Core (L1) address discovery** — gap-limit scanning (lookahead 20) that extends the receiving/change chains as addresses are used. Triggered on startup, wallet select, post-sync activity (debounced), and a periodic interval; concurrent runs de-duped.
- **Shielded address persistence** — shielded addresses saved to SQLite (`shielded_addresses` table) so they list without re-entering the password; auto-derived on wallet creation.
- **Platform (L2) window auto-extension** — probes balance/nonce forward and grows the persisted platform address window on demand.
- **Periodic balance refresh** — shared 30s refresh timer in `useAsyncWithCache`, wired into `useWalletBalance`.
- **`getUsedAddresses` on `WalletProvider`** — active usage probe via Insight (rpc); P2P relies on passive `is_used` marking during block apply.
- New `wallet.core_xpub` column and migrations `0014_core_xpub`, `0015_shielded_addresses`.
- Unit tests for gap-extension planning and core-xpub key derivation.

