### PR TITLE
Frontend fixes: easy issues batch

### DIFF
--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -63,7 +63,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
     [wallets]
   )
 
-  const { desired, showSyncUI, setDesired } = useConnectionModeContext()
+  const { desired, showSyncUI, fallbackActive, setDesired } = useConnectionModeContext()
 
   const handleWalletChange = (walletId: string): void => {
     if (!walletId || walletId === selectedWallet) return
@@ -97,6 +97,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
             options={connectionOptions}
             value={desired}
             onChange={(value) => setDesired(value as ConnectionType)}
+            syncing={fallbackActive}
           />
           <button
             onMouseEnter={hoverNotification.onMouseEnter}

--- a/src/renderer/src/components/dash-ui-kit-enxtended/text/index.tsx
+++ b/src/renderer/src/components/dash-ui-kit-enxtended/text/index.tsx
@@ -12,7 +12,7 @@ const textStyles = cva(
         default: 'text-gray-900 dark:text-gray-100',
         'blue-mint': 'text-dash-brand dark:text-dash-mint',
         'blue-dark': 'text-dash-brand-dark dark:text-dash-brand-dim',
-        red: 'text-red-700',
+        red: 'text-red-700 dark:text-red-400',
         brand: 'text-dash-primary-dark-blue dark:text-white',
         blue: 'text-dash-brand',
         white: 'text-white',

--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
 import { useTheme } from 'dash-ui-kit/react'
 import { API } from '@renderer/api'
 import { AssetLockFundingKind, AssetLockFundingState } from '@renderer/api/types'
@@ -11,7 +11,7 @@ import HashField from '@renderer/components/ui/HashField'
 import CopyableError from '@renderer/components/ui/CopyableError'
 import CopyButton from '@renderer/components/ui/CopyButton'
 import { useAuth } from '@renderer/contexts/AuthContext'
-import { transactionUrl } from '@renderer/utils/explorer'
+import { transactionUrl, platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
 import { ASSET_LOCK_FUNDING_POLL_MS } from '@renderer/constants'
 
 interface AssetLockFundingModalProps {
@@ -198,6 +198,8 @@ export default function AssetLockFundingModal({
   }
 
   const isDone = started && state?.phase === AssetLockFundingPhase.Done
+  const doneTxid = state?.txid ?? null
+  const doneStHash = state?.stHash ?? null
   const isError = started && (state?.phase === AssetLockFundingPhase.Error || state?.phase === AssetLockFundingPhase.Resumable)
   const texts = TEXTS[kind]
   const phases = PHASE_LABELS[kind]
@@ -364,6 +366,18 @@ export default function AssetLockFundingModal({
               )}
             </div>
             <div className={"mt-4.5 flex gap-2"}>
+              {doneTxid && network && (
+                <Button type={"button"} onClick={() => openExternal(transactionUrl(doneTxid, network))} variant={"outline"} colorScheme={"primary-light"} size={"md"} className={"flex-1 rounded-[.9375rem] gap-2"}>
+                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+                  L1 explorer
+                </Button>
+              )}
+              {doneStHash && network && (
+                <Button type={"button"} onClick={() => openExternal(platformTransactionUrl(doneStHash, network))} variant={"outline"} colorScheme={"primary-light"} size={"md"} className={"flex-1 rounded-[.9375rem] gap-2"}>
+                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+                  Platform explorer
+                </Button>
+              )}
               <Button type={"button"} onClick={onClose} variant={"solid"} colorScheme={"lightBlue-mint"} size={"md"} className={"flex-1 rounded-[.9375rem]"}>
                 Done
               </Button>

--- a/src/renderer/src/components/modal/ShieldConfirmModal.tsx
+++ b/src/renderer/src/components/modal/ShieldConfirmModal.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, ShieldSmallIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, ShieldSmallIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
 import { useTheme } from 'dash-ui-kit/react'
+import { useAuth } from '@renderer/contexts/AuthContext'
 import { API } from '@renderer/api'
 import { ShieldResult } from '@renderer/api/types'
+import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
 import { ConfirmModalPhase } from '@renderer/enums/ConfirmModalPhase'
 import Spinner from '@renderer/components/ui/Spinner'
 import CopyableError from '@renderer/components/ui/CopyableError'
@@ -34,6 +36,8 @@ export default function ShieldConfirmModal({
   onSuccess,
 }: ShieldConfirmModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
+  const { status } = useAuth()
+  const network = status?.network ?? null
   const [password, setPassword] = useState('')
   const [phase, setPhase] = useState<ConfirmModalPhase>(ConfirmModalPhase.Confirm)
   const [error, setError] = useState<string | null>(null)
@@ -202,6 +206,19 @@ export default function ShieldConfirmModal({
             </div>
 
             <div className={"mt-4.5 flex gap-2"}>
+              {result?.stHash && network && (
+                <Button
+                  type={"button"}
+                  onClick={() => openExternal(platformTransactionUrl(result.stHash, network))}
+                  variant={"outline"}
+                  colorScheme={"primary-light"}
+                  size={"md"}
+                  className={"flex-1 rounded-[.9375rem] gap-2"}
+                >
+                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+                  View on explorer
+                </Button>
+              )}
               <Button
                 type={"button"}
                 onClick={onClose}

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -1,12 +1,14 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
 import HashField from '@renderer/components/ui/HashField'
 import CopyableError from '@renderer/components/ui/CopyableError'
 import CreditsAmount from '@renderer/components/ui/CreditsAmount'
 import { useTheme } from 'dash-ui-kit/react'
+import { useAuth } from '@renderer/contexts/AuthContext'
 import { API } from '@renderer/api'
 import { ShieldedSpendState } from '@renderer/api/types'
+import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
 import { ShieldedSpendPhase } from '@renderer/enums/ShieldedSpendPhase'
 import Spinner from '@renderer/components/ui/Spinner'
 import { SHIELDED_SPEND_POLL_MS, SHIELDED_SPEND_RETRY_MS } from '@renderer/constants'
@@ -48,6 +50,8 @@ export default function ShieldedSpendModal({
   onSuccess,
 }: ShieldedSpendModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
+  const { status } = useAuth()
+  const network = status?.network ?? null
   const [password, setPassword] = useState('')
   const [preError, setPreError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -137,6 +141,7 @@ export default function ShieldedSpendModal({
   }
 
   const isDone = spend?.phase === ShieldedSpendPhase.Done
+  const doneStHash = spend?.stHash ?? null
   const isError = started && spend?.phase === ShieldedSpendPhase.Error
   const confirmLabel = busy ? 'Starting…' : !proverReady ? 'Preparing…' : 'Confirm & Send'
 
@@ -278,6 +283,12 @@ export default function ShieldedSpendModal({
               {spend?.stHash && <HashField hash={spend.stHash} />}
             </div>
             <div className={"mt-4.5 flex gap-2"}>
+              {doneStHash && network && (
+                <Button type={"button"} onClick={() => openExternal(platformTransactionUrl(doneStHash, network))} variant={"outline"} colorScheme={"primary-light"} size={"md"} className={"flex-1 rounded-[.9375rem] gap-2"}>
+                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+                  View on explorer
+                </Button>
+              )}
               <Button type={"button"} onClick={onClose} variant={"solid"} colorScheme={"lightBlue-mint"} size={"md"} className={"flex-1 rounded-[.9375rem]"}>
                 Done
               </Button>

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -24,6 +24,7 @@ interface ShieldedSpendModalProps {
   proverReady: boolean
   start: (password: string) => Promise<ShieldedSpendState>
   onSuccess: () => void
+  successNote?: string
 }
 
 const PHASES = [
@@ -48,6 +49,7 @@ export default function ShieldedSpendModal({
   proverReady,
   start,
   onSuccess,
+  successNote,
 }: ShieldedSpendModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
   const { status } = useAuth()
@@ -277,6 +279,11 @@ export default function ShieldedSpendModal({
                   ? `Funded with ${sentAmount || amountCredits} credits from the pool (minus the Platform fee). Re-sync notes to update your balance.`
                   : 'Broadcast to Platform. Re-sync notes to update your balance.'}
               </Text>
+              {successNote && (
+                <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-2 leading-[130%]"}>
+                  {successNote}
+                </Text>
+              )}
             </div>
             <div className={"mt-5 flex flex-col gap-[.75rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>
               {spend?.identityId && <HashField hash={spend.identityId} label={"Identity"} />}

--- a/src/renderer/src/components/modal/TransferConfirmModal.tsx
+++ b/src/renderer/src/components/modal/TransferConfirmModal.tsx
@@ -25,6 +25,7 @@ interface TransferConfirmModalProps {
   rows: TransferConfirmRow[]
   run: (password: string) => Promise<PlatformSendResult>
   onSuccess: () => void
+  successNote?: string
 }
 
 
@@ -36,6 +37,7 @@ export default function TransferConfirmModal({
   rows,
   run,
   onSuccess,
+  successNote,
 }: TransferConfirmModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
   const { status } = useAuth()
@@ -176,6 +178,11 @@ export default function TransferConfirmModal({
               <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>
                 Broadcast to Platform. It will confirm shortly.
               </Text>
+              {successNote && (
+                <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-2 leading-[130%]"}>
+                  {successNote}
+                </Text>
+              )}
             </div>
 
             <div className={"mt-5 flex flex-col gap-[.75rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>

--- a/src/renderer/src/components/modal/TransferConfirmModal.tsx
+++ b/src/renderer/src/components/modal/TransferConfirmModal.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
 import { useTheme } from 'dash-ui-kit/react'
+import { useAuth } from '@renderer/contexts/AuthContext'
 import { PlatformSendResult } from '@renderer/api/types'
 import { ConfirmModalPhase } from '@renderer/enums/ConfirmModalPhase'
+import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
 import Spinner from '@renderer/components/ui/Spinner'
 import CopyableError from '@renderer/components/ui/CopyableError'
 import HashField from '@renderer/components/ui/HashField'
@@ -36,6 +38,8 @@ export default function TransferConfirmModal({
   onSuccess,
 }: TransferConfirmModalProps): React.JSX.Element | null {
   const { theme } = useTheme()
+  const { status } = useAuth()
+  const network = status?.network ?? null
   const [password, setPassword] = useState('')
   const [phase, setPhase] = useState<ConfirmModalPhase>(ConfirmModalPhase.Confirm)
   const [error, setError] = useState<string | null>(null)
@@ -193,6 +197,19 @@ export default function TransferConfirmModal({
             </div>
 
             <div className={"mt-4.5 flex gap-2"}>
+              {result?.stHash && network && (
+                <Button
+                  type={"button"}
+                  onClick={() => openExternal(platformTransactionUrl(result.stHash, network))}
+                  variant={"outline"}
+                  colorScheme={"primary-light"}
+                  size={"md"}
+                  className={"flex-1 rounded-[.9375rem] gap-2"}
+                >
+                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
+                  View on explorer
+                </Button>
+              )}
               <Button
                 type={"button"}
                 onClick={onClose}

--- a/src/renderer/src/components/pages/addresses/AddressCard.tsx
+++ b/src/renderer/src/components/pages/addresses/AddressCard.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react'
 import { BigNumber } from 'dash-ui-kit/react'
-import { Text } from '@renderer/components/dash-ui-kit-enxtended'
+import { Text, ExternalLinkIcon } from '@renderer/components/dash-ui-kit-enxtended'
 import { ReceiveIcon } from '@renderer/components/dash-ui-kit-enxtended/icons'
 import { WalletAddressDto } from '@renderer/api/types'
 import { davToDashCompact } from '@renderer/utils/balance'
 import { useFiat } from '@renderer/hooks/useFiat'
+import { useAuth } from '@renderer/contexts/AuthContext'
+import { addressUrl, openExternal } from '@renderer/utils/explorer'
 import CustomBadge from '@renderer/components/ui/CustomBadge'
 import CopyButton from '@renderer/components/ui/CopyButton'
 import QrButton from '@renderer/components/ui/QrButton'
@@ -17,6 +19,8 @@ export default function AddressCard({
 }: WalletAddressDto): React.JSX.Element {
   const [isQrOpen, setIsQrOpen] = useState(false)
   const { format: formatFiat, rateReady } = useFiat()
+  const { status: appStatus } = useAuth()
+  const network = appStatus?.network ?? null
 
   return (
     <div className={"flex items-center justify-between px-[.9375rem] py-[.625rem] rounded-[.875rem] dash-block"}>
@@ -30,6 +34,15 @@ export default function AddressCard({
           </Text>
           <CopyButton text={address} />
           <QrButton onClick={() => setIsQrOpen(true)} />
+          {network && (
+            <button
+              onClick={() => openExternal(addressUrl(address, network))}
+              title={"Open in explorer"}
+              className={"size-5 rounded-[.3125rem] flex items-center justify-center dash-block-5 hover:opacity-80 transition-opacity duration-200 cursor-pointer"}
+            >
+              <ExternalLinkIcon size={10} color={"currentColor"} className={"dash-text-default opacity-50"} />
+            </button>
+          )}
         </div>
         <Text size={10} weight={"medium"} color={"default"} opacity={50}>
           Tx count: <span className={"font-bold"}>{txCount}</span>

--- a/src/renderer/src/components/pages/addresses/PlatformAddressCard.tsx
+++ b/src/renderer/src/components/pages/addresses/PlatformAddressCard.tsx
@@ -1,5 +1,7 @@
-import { Text } from '@renderer/components/dash-ui-kit-enxtended'
+import { Text, ExternalLinkIcon } from '@renderer/components/dash-ui-kit-enxtended'
 import { PlatformAddressDto } from '@renderer/api/types'
+import { useAuth } from '@renderer/contexts/AuthContext'
+import { platformAddressUrl, openExternal } from '@renderer/utils/explorer'
 import CopyButton from '@renderer/components/ui/CopyButton'
 import CreditsAmount from '@renderer/components/ui/CreditsAmount'
 
@@ -8,6 +10,9 @@ export default function PlatformAddressCard({
   balanceCredits,
   nonce,
 }: PlatformAddressDto): React.JSX.Element {
+  const { status: appStatus } = useAuth()
+  const network = appStatus?.network ?? null
+
   return (
     <div className={"flex items-center justify-between px-[.9375rem] py-[.625rem] rounded-[.875rem] dash-block"}>
       <div className={"flex flex-col gap-1 min-w-0"}>
@@ -16,6 +21,15 @@ export default function PlatformAddressCard({
             {platformAddress}
           </Text>
           <CopyButton text={platformAddress} />
+          {network && (
+            <button
+              onClick={() => openExternal(platformAddressUrl(platformAddress, network))}
+              title={"Open in explorer"}
+              className={"size-5 rounded-[.3125rem] flex items-center justify-center dash-block-5 hover:opacity-80 transition-opacity duration-200 cursor-pointer"}
+            >
+              <ExternalLinkIcon size={10} color={"currentColor"} className={"dash-text-default opacity-50"} />
+            </button>
+          )}
         </div>
         <Text size={10} weight={"medium"} color={"default"} opacity={50}>
           Tx count: <span className={"font-bold"}>{nonce}</span>

--- a/src/renderer/src/components/pages/auth/CreateWallet.tsx
+++ b/src/renderer/src/components/pages/auth/CreateWallet.tsx
@@ -6,6 +6,8 @@ import { CreateWalletTexts, messages } from '@renderer/constants';
 import { getPasswordValidationError } from '@renderer/utils/passwordValidation';
 import { toast } from '@renderer/components/ui/Toast';
 import Spinner from '@renderer/components/ui/Spinner';
+import { useDelayedVisible } from '@renderer/hooks/useDelayedVisible';
+import { WALLET_CREATE_SLOW_NOTICE_MS } from '@renderer/constants';
 
 type CreateWalletData = Pick<
   CreateWalletTexts,
@@ -13,7 +15,8 @@ type CreateWalletData = Pick<
   'placeholderConfirmPassword' |
   'buttonNext' |
   'labelPassword' |
-  'placeholderPassword'
+  'placeholderPassword' |
+  'slowCreationNotice'
 >
 
 type CreateWalletProps = Pick<TypeUseCreateWallet, 'password' | 'setPassword'> & {
@@ -30,6 +33,7 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const showSlowNotice = useDelayedVisible(loading, WALLET_CREATE_SLOW_NOTICE_MS)
   const { theme } = useTheme()
   const iconColor = theme === 'dark' ? '#ffffff' : ''
 
@@ -128,6 +132,11 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
       >
         {loading ? <Spinner size={20} className={"mx-auto"} /> : data.buttonNext}
       </Button>
+      {showSlowNotice &&
+        <Text as={"p"} size={14} weight={"medium"} color={"brand"} opacity={50} className={"text-center"}>
+          {data.slowCreationNotice}
+        </Text>
+      }
     </form>
   )
 }

--- a/src/renderer/src/components/pages/auth/CreateWallet.tsx
+++ b/src/renderer/src/components/pages/auth/CreateWallet.tsx
@@ -23,7 +23,7 @@ type CreateWalletProps = Pick<TypeUseCreateWallet, 'password' | 'setPassword'> &
 }
 
 const { createWallet: { passwordValidation: { passwordsDoNotMatch },
-  seedPhrase: { warning, errorMessage, errorTitle }
+  seedPhrase: { errorMessage, errorTitle }
 }} = messages
 
 export default function  CreateWallet({ password, setPassword, generateSeedPhrase, createImportedWallet, data } : CreateWalletProps): React.JSX.Element {
@@ -57,7 +57,6 @@ export default function  CreateWallet({ password, setPassword, generateSeedPhras
           await generateSeedPhrase()
         }
       }
-      toast.error(warning)
     } catch (err) {
       const message =
         err instanceof Error

--- a/src/renderer/src/components/pages/auth/VerifySeedPhrase.tsx
+++ b/src/renderer/src/components/pages/auth/VerifySeedPhrase.tsx
@@ -2,13 +2,15 @@ import { useState, useEffect } from "react"
 import { Button, Text } from "@renderer/components/dash-ui-kit-enxtended"
 import { TypeUseCreateWallet } from "@renderer/hooks/useCreateWallet";
 import SeedPhraseWarning from "./SeedPhraseWarning";
-import { BaseTexts, FillInYourSeedPhraseTexts } from "@renderer/constants";
+import { BaseTexts, FillInYourSeedPhraseTexts, WALLET_CREATE_SLOW_NOTICE_MS } from "@renderer/constants";
+import { useDelayedVisible } from "@renderer/hooks/useDelayedVisible";
 
 type VerifySeedPhraseData = Pick<
   FillInYourSeedPhraseTexts,
   'buttonContinue'
 > & {
   seedPhraseWarning: BaseTexts
+  slowCreationNotice: string
 }
 
 type VerifySeedPhraseProps = Pick<TypeUseCreateWallet, 'verifyPhrase' | 'verifyMissingWords'> & {
@@ -18,6 +20,7 @@ type VerifySeedPhraseProps = Pick<TypeUseCreateWallet, 'verifyPhrase' | 'verifyM
 export default function VerifySeedPhrase({ verifyPhrase, verifyMissingWords, data } : VerifySeedPhraseProps): React.JSX.Element {
   const [answers, setAnswers] = useState<string[]>(() => [...verifyPhrase])
   const [loading, setLoading] = useState(false)
+  const showSlowNotice = useDelayedVisible(loading, WALLET_CREATE_SLOW_NOTICE_MS)
 
   useEffect(() => {
     setAnswers([...verifyPhrase])
@@ -115,6 +118,12 @@ export default function VerifySeedPhrase({ verifyPhrase, verifyMissingWords, dat
           {data.buttonContinue}
         </Button>
       </div>
+
+      {showSlowNotice &&
+        <Text as={"p"} size={14} weight={"medium"} color={"brand"} opacity={50} className={"text-center"}>
+          {data.slowCreationNotice}
+        </Text>
+      }
     </div>
   )
 }

--- a/src/renderer/src/components/pages/dashboard/IdentitiesCard.tsx
+++ b/src/renderer/src/components/pages/dashboard/IdentitiesCard.tsx
@@ -71,13 +71,6 @@ export default function IdentitiesCard(): React.JSX.Element {
       {identities.length === 0 ? (
         <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"leading-[150%]"}>
           {labels.empty}
-          {' · '}
-          <button
-            onClick={() => navigate('/send?from=core&to=newIdentity')}
-            className={"cursor-pointer hover:opacity-80 transition-opacity duration-200 text-dash-brand dark:text-dash-mint"}
-          >
-            {labels.register}
-          </button>
         </Text>
       ) : (
         <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={`leading-[150%] ${blur}`}>

--- a/src/renderer/src/components/pages/identities/IdentityCard.tsx
+++ b/src/renderer/src/components/pages/identities/IdentityCard.tsx
@@ -5,7 +5,7 @@ import AmountSummary from "@renderer/components/ui/AmountSummary";
 import CopyButton from "@renderer/components/ui/CopyButton";
 import CreditsAmount from "@renderer/components/ui/CreditsAmount";
 import { useAuth } from "@renderer/contexts/AuthContext";
-import { transactionUrl, openExternal } from "@renderer/utils/explorer";
+import { transactionUrl, identityUrl, openExternal } from "@renderer/utils/explorer";
 
 export default function IdentityCard({identity}: {identity: Identity}): React.JSX.Element {
   const { status } = useAuth()
@@ -22,6 +22,15 @@ export default function IdentityCard({identity}: {identity: Identity}): React.JS
             {identity.walletAddress}
           </Identifier>
           <CopyButton text={identity.walletAddress} />
+          {network && (
+            <button
+              onClick={() => openExternal(identityUrl(identity.walletAddress, network))}
+              title={"Open in explorer"}
+              className={"cursor-pointer hover:opacity-60"}
+            >
+              <ExternalLinkIcon size={10} color={"currentColor"} className={"dash-text-default opacity-70"} />
+            </button>
+          )}
         </div>
         {identity.name && <Text size={10} weight={"medium"} color={"default"} opacity={50}>Username: <span className={"font-bold"}>{identity.name}</span></Text>}
         {identity.assetLockTxid && (

--- a/src/renderer/src/components/pages/transactions/TransactionDetail.tsx
+++ b/src/renderer/src/components/pages/transactions/TransactionDetail.tsx
@@ -18,7 +18,6 @@ import { useFiat } from '@renderer/hooks/useFiat'
 import { transactionUrl, openExternal } from '@renderer/utils/explorer'
 import { ExternalLinkIcon } from '@renderer/components/dash-ui-kit-enxtended'
 import { useAuth } from '@renderer/contexts/AuthContext'
-import QrButton from '@renderer/components/ui/QrButton'
 
 const cardStyles = cva(
   'flex flex-col gap-5 p-[.9375rem] rounded-[.9375rem] dash-card-base shadow-[0_0_50px_0_rgba(0,0,0,0.1)]'
@@ -131,7 +130,6 @@ export default function TransactionDetail({ transaction, onBack }: TransactionDe
               <ExternalLinkIcon size={12} color={"currentColor"} className={"dash-text-default opacity-50"} />
             </button>
           )}
-          <QrButton />
         </div>
       </div>
 

--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -42,7 +42,7 @@ import { AssetLockFundingPhase } from "@renderer/enums/AssetLockFundingPhase";
 import { AssetLockFundingKind } from "@renderer/enums/AssetLockFundingKind";
 import { API } from "@renderer/api";
 import { AssetLockFundingState, PlatformAddressDto, ShieldedSpendState } from "@renderer/api/types";
-import { sendPageData, MAX_SPEND_NOTES } from "@renderer/constants";
+import { sendPageData, MAX_SPEND_NOTES, WITHDRAWAL_SUCCESS_NOTE } from "@renderer/constants";
 import AmountField from "./AmountField";
 import AmountSlider from "./AmountSlider";
 import TransferWizard from "./TransferWizard";
@@ -759,6 +759,7 @@ export default function TransferHub(): React.JSX.Element {
           proverReady={prover.ready}
           start={startShieldedSpend}
           onSuccess={resetForm}
+          successNote={operation === TransferOperation.ShieldedWithdrawal ? WITHDRAWAL_SUCCESS_NOTE : undefined}
         />
       )}
 
@@ -809,6 +810,7 @@ export default function TransferHub(): React.JSX.Element {
           ]}
           run={runPlatformOperation}
           onSuccess={resetForm}
+          successNote={operation === TransferOperation.AddressWithdrawal || operation === TransferOperation.IdentityWithdrawal ? WITHDRAWAL_SUCCESS_NOTE : undefined}
         />
       )}
 

--- a/src/renderer/src/components/ui/ConnectionSelect.tsx
+++ b/src/renderer/src/components/ui/ConnectionSelect.tsx
@@ -15,14 +15,20 @@ export interface ConnectionSelectProps {
   options: ConnectionSelectOption[]
   value: string
   onChange: (value: string) => void
+  syncing?: boolean
   className?: string
 }
 
-export function StatusDot({ active }: { active: boolean }): React.JSX.Element {
+export function StatusDot({ active, busy = false }: { active: boolean; busy?: boolean }): React.JSX.Element {
   if (active) {
     return (
       <span
-        className={`
+        className={busy
+          ? `
+          block size-3 shrink-0 rounded-full bg-dash-orange
+          shadow-[0_0_12px_var(--color-dash-orange)]
+        `
+          : `
           block size-3 shrink-0 rounded-full bg-dash-mint
           shadow-[0_0_12px_var(--color-dash-mint)]
         `}
@@ -65,6 +71,7 @@ export default function ConnectionSelect({
   options,
   value,
   onChange,
+  syncing = false,
   className = '',
 }: ConnectionSelectProps): React.JSX.Element {
   const [isOpen, setIsOpen] = useState(false)
@@ -109,7 +116,7 @@ export default function ConnectionSelect({
           focus:outline-none
         `}
       >
-        <StatusDot active={true} />
+        <StatusDot active={true} busy={syncing} />
         <div className={"flex items-center min-w-0 flex-1 text-left"}>
           <Text size={14} weight={"medium"} color={"brand"} className={"truncate max-w-full"}>
             {selectedOption?.label}
@@ -136,7 +143,7 @@ export default function ConnectionSelect({
               `}
             >
               <div className={"flex items-center gap-3 min-w-0 flex-1"}>
-                <StatusDot active={isSelected} />
+                <StatusDot active={isSelected} busy={isSelected && syncing} />
                 <Text size={14} weight={"medium"} color={"brand"} className={"truncate max-w-full"}>
                   {option.label}
                 </Text>

--- a/src/renderer/src/constants/auth.ts
+++ b/src/renderer/src/constants/auth.ts
@@ -10,6 +10,7 @@ export interface CreateWalletTexts extends BaseTexts {
   placeholderConfirmPassword: string
   buttonNext: string
   importWallet: string
+  slowCreationNotice: string
 }
 
 export interface SaveYourSeedPhraseTexts extends BaseTexts {
@@ -60,7 +61,8 @@ export const authTexts: AuthTexts = {
     placeholderPassword: 'Type Your Password',
     placeholderConfirmPassword: 'Repeat your Password',
     buttonNext: 'Next',
-    importWallet: 'Import wallet instead'
+    importWallet: 'Import wallet instead',
+    slowCreationNotice: 'Securing your wallet can take a while on some machines. Everything is fine, just wait a little bit longer.'
   },
   saveYourSeedPhrase: {
     title: 'Save your Seed Phrase',

--- a/src/renderer/src/constants/dashboardPage.ts
+++ b/src/renderer/src/constants/dashboardPage.ts
@@ -37,8 +37,7 @@ export const dashboardPage = {
     many: 'identities',
     top: 'top',
     credits: 'credits',
-    empty: 'No identities yet',
-    register: 'Register identity'
+    empty: 'No identities yet'
   },
   network: {
     title: 'Network',

--- a/src/renderer/src/constants/intervals.ts
+++ b/src/renderer/src/constants/intervals.ts
@@ -1,3 +1,4 @@
 export const APP_STATUS_POLL_MS = 1_000
 export const BALANCE_REFRESH_MS = 30_000
 export const ASSET_LOCK_FUNDING_POLL_MS = 1_500
+export const WALLET_CREATE_SLOW_NOTICE_MS = 5_000

--- a/src/renderer/src/constants/messages.ts
+++ b/src/renderer/src/constants/messages.ts
@@ -9,7 +9,6 @@ export interface Messages {
       passwordsDoNotMatch: string
     }
     seedPhrase: {
-      warning: string
       errorMessage: string
       errorTitle: string
     }
@@ -36,7 +35,6 @@ export const messages: Messages = {
     },
 
     seedPhrase: {
-      warning: '**DO NOT share your recovery phrase with ANYONE.** Anyone with your recovery phrase can have full control over your assets. Please stay vigilant against phishing attacks at all times.',
       errorMessage: 'Unexpected error while generating seed phrase.',
       errorTitle: '**Something went wrong**',
     },

--- a/src/renderer/src/constants/sendPages.ts
+++ b/src/renderer/src/constants/sendPages.ts
@@ -19,6 +19,8 @@ export interface TransferPageType {
   }
 }
 
+export const WITHDRAWAL_SUCCESS_NOTE = 'Withdrawals are processed by Core with a delay — the Dash payout usually takes several minutes to appear in your transaction list.'
+
 export const sendPageData: TransferPageType = {
   header: {
     title: 'Send',

--- a/src/renderer/src/hooks/useDelayedVisible.ts
+++ b/src/renderer/src/hooks/useDelayedVisible.ts
@@ -1,0 +1,16 @@
+import { useState, useEffect } from 'react'
+
+export function useDelayedVisible(active: boolean, delayMs: number): boolean {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    if (!active) {
+      setVisible(false)
+      return
+    }
+    const timer = setTimeout(() => setVisible(true), delayMs)
+    return () => clearTimeout(timer)
+  }, [active, delayMs])
+
+  return visible
+}

--- a/src/renderer/src/pages/auth/CreateWalletWrapper.tsx
+++ b/src/renderer/src/pages/auth/CreateWalletWrapper.tsx
@@ -157,7 +157,8 @@ export default function CreateWalletWrapper(): React.JSX.Element {
               placeholderConfirmPassword: createWallet.placeholderConfirmPassword,
               buttonNext: createWallet.buttonNext,
               labelPassword: createWallet.labelPassword,
-              placeholderPassword: createWallet.placeholderPassword
+              placeholderPassword: createWallet.placeholderPassword,
+              slowCreationNotice: createWallet.slowCreationNotice
             }}
           />
         }
@@ -172,7 +173,8 @@ export default function CreateWalletWrapper(): React.JSX.Element {
               placeholderConfirmPassword: createWallet.placeholderConfirmPassword,
               buttonNext: createWallet.buttonNext,
               labelPassword: createWallet.labelPassword,
-              placeholderPassword: createWallet.placeholderPassword
+              placeholderPassword: createWallet.placeholderPassword,
+              slowCreationNotice: createWallet.slowCreationNotice
             }}
           />
         }
@@ -194,7 +196,8 @@ export default function CreateWalletWrapper(): React.JSX.Element {
             verifyMissingWords={verifyMissingWords}
             data={{
               buttonContinue: fillInYourSeedPhrase.buttonContinue,
-              seedPhraseWarning: seedPhraseWarning
+              seedPhraseWarning: seedPhraseWarning,
+              slowCreationNotice: createWallet.slowCreationNotice
             }}
         />}
 

--- a/src/renderer/src/utils/explorer.ts
+++ b/src/renderer/src/utils/explorer.ts
@@ -22,6 +22,14 @@ export function addressUrl(address: string, network: Network): string {
   return `${EXPLORER_HOST[network]}/address/${address}`
 }
 
+export function platformAddressUrl(address: string, network: Network): string {
+  return `${PLATFORM_EXPLORER_HOST[network]}/platformAddress/${address}`
+}
+
+export function identityUrl(id: string, network: Network): string {
+  return `${PLATFORM_EXPLORER_HOST[network]}/identity/${id}`
+}
+
 export function openExternal(url: string): void {
   window.open(url, '_blank', 'noopener,noreferrer')
 }

--- a/src/renderer/src/utils/explorer.ts
+++ b/src/renderer/src/utils/explorer.ts
@@ -9,6 +9,10 @@ export function transactionUrl(txid: string, network: Network): string {
   return `${EXPLORER_HOST[network]}/transactions/${txid}`
 }
 
+export function addressUrl(address: string, network: Network): string {
+  return `${EXPLORER_HOST[network]}/address/${address}`
+}
+
 export function openExternal(url: string): void {
   window.open(url, '_blank', 'noopener,noreferrer')
 }

--- a/src/renderer/src/utils/explorer.ts
+++ b/src/renderer/src/utils/explorer.ts
@@ -5,8 +5,17 @@ const EXPLORER_HOST: Record<Network, string> = {
   testnet: 'https://testnet.dashscan.io',
 }
 
+const PLATFORM_EXPLORER_HOST: Record<Network, string> = {
+  mainnet: 'https://platform-explorer.com',
+  testnet: 'https://testnet.platform-explorer.com',
+}
+
 export function transactionUrl(txid: string, network: Network): string {
   return `${EXPLORER_HOST[network]}/transactions/${txid}`
+}
+
+export function platformTransactionUrl(hash: string, network: Network): string {
+  return `${PLATFORM_EXPLORER_HOST[network]}/transaction/${hash}`
 }
 
 export function addressUrl(address: string, network: Network): string {

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest'
-import { transactionUrl, addressUrl, platformTransactionUrl } from '../../src/renderer/src/utils/explorer'
+import { transactionUrl, addressUrl, platformTransactionUrl, platformAddressUrl, identityUrl } from '../../src/renderer/src/utils/explorer'
 
 const TXID = '0093d045fb4cc527896b50890d84b572c78dfddc1f75857247065929bb0fce4f'
 const ADDRESS = 'XdAUmwtig27HBG6WfYyHAzP8n6XC9jESEw'
 const ST_HASH = '3B5A2C0335F87C87B9C0C25C6224D2A0022D6D0EE1D2D4B72F02E57D1F9FED5F'
+const PLATFORM_ADDRESS = 'dash1kp2ld9lldeh43ajshkt3djk48rqgrggy5ue2cayd'
+const IDENTITY_ID = '3MvpYDCTH9RmbpeJU7C1nYe3tLhf28UQA5PMAmKy4TeC'
 
 describe('transactionUrl', () => {
   it('builds a testnet dashscan url', () => {
@@ -43,6 +45,34 @@ describe('platformTransactionUrl', () => {
   it('builds a mainnet platform explorer url', () => {
     expect(platformTransactionUrl(ST_HASH, 'mainnet')).toBe(
       `https://platform-explorer.com/transaction/${ST_HASH}`,
+    )
+  })
+})
+
+describe('platformAddressUrl', () => {
+  it('builds a testnet platform explorer url', () => {
+    expect(platformAddressUrl(PLATFORM_ADDRESS, 'testnet')).toBe(
+      `https://testnet.platform-explorer.com/platformAddress/${PLATFORM_ADDRESS}`,
+    )
+  })
+
+  it('builds a mainnet platform explorer url', () => {
+    expect(platformAddressUrl(PLATFORM_ADDRESS, 'mainnet')).toBe(
+      `https://platform-explorer.com/platformAddress/${PLATFORM_ADDRESS}`,
+    )
+  })
+})
+
+describe('identityUrl', () => {
+  it('builds a testnet platform explorer url', () => {
+    expect(identityUrl(IDENTITY_ID, 'testnet')).toBe(
+      `https://testnet.platform-explorer.com/identity/${IDENTITY_ID}`,
+    )
+  })
+
+  it('builds a mainnet platform explorer url', () => {
+    expect(identityUrl(IDENTITY_ID, 'mainnet')).toBe(
+      `https://platform-explorer.com/identity/${IDENTITY_ID}`,
     )
   })
 })

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { transactionUrl } from '../../src/renderer/src/utils/explorer'
+import { transactionUrl, addressUrl } from '../../src/renderer/src/utils/explorer'
 
 const TXID = '0093d045fb4cc527896b50890d84b572c78dfddc1f75857247065929bb0fce4f'
+const ADDRESS = 'XdAUmwtig27HBG6WfYyHAzP8n6XC9jESEw'
 
 describe('transactionUrl', () => {
   it('builds a testnet dashscan url', () => {
@@ -13,6 +14,20 @@ describe('transactionUrl', () => {
   it('builds a mainnet dashscan url', () => {
     expect(transactionUrl(TXID, 'mainnet')).toBe(
       `https://dashscan.io/transactions/${TXID}`,
+    )
+  })
+})
+
+describe('addressUrl', () => {
+  it('builds a testnet dashscan url', () => {
+    expect(addressUrl(ADDRESS, 'testnet')).toBe(
+      `https://testnet.dashscan.io/address/${ADDRESS}`,
+    )
+  })
+
+  it('builds a mainnet dashscan url', () => {
+    expect(addressUrl(ADDRESS, 'mainnet')).toBe(
+      `https://dashscan.io/address/${ADDRESS}`,
     )
   })
 })

--- a/tests/unit/explorer.test.ts
+++ b/tests/unit/explorer.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { transactionUrl, addressUrl } from '../../src/renderer/src/utils/explorer'
+import { transactionUrl, addressUrl, platformTransactionUrl } from '../../src/renderer/src/utils/explorer'
 
 const TXID = '0093d045fb4cc527896b50890d84b572c78dfddc1f75857247065929bb0fce4f'
 const ADDRESS = 'XdAUmwtig27HBG6WfYyHAzP8n6XC9jESEw'
+const ST_HASH = '3B5A2C0335F87C87B9C0C25C6224D2A0022D6D0EE1D2D4B72F02E57D1F9FED5F'
 
 describe('transactionUrl', () => {
   it('builds a testnet dashscan url', () => {
@@ -28,6 +29,20 @@ describe('addressUrl', () => {
   it('builds a mainnet dashscan url', () => {
     expect(addressUrl(ADDRESS, 'mainnet')).toBe(
       `https://dashscan.io/address/${ADDRESS}`,
+    )
+  })
+})
+
+describe('platformTransactionUrl', () => {
+  it('builds a testnet platform explorer url', () => {
+    expect(platformTransactionUrl(ST_HASH, 'testnet')).toBe(
+      `https://testnet.platform-explorer.com/transaction/${ST_HASH}`,
+    )
+  })
+
+  it('builds a mainnet platform explorer url', () => {
+    expect(platformTransactionUrl(ST_HASH, 'mainnet')).toBe(
+      `https://platform-explorer.com/transaction/${ST_HASH}`,
     )
   })
 })


### PR DESCRIPTION
Fixes for the easy frontend issues:

- #93 — removed the register identity button (dashboard card entry point)
- #92 — removed the useless QR button from transaction details
- #72 — removed the pointless red toast on wallet creation
- #80 — red error text readable in dark theme (`dark:text-red-400` on the Text component)
- #82 — explorer links in the address list: Dashscan for L1, Platform Explorer for platform addresses and identities
- #86 — explorer link buttons on successful transfer (both L1 + L2 links for bridging via asset lock)
- #85 — note on the withdrawal success screen explaining the L1 payout delay
- #96 — reassuring notice after 5s of slow key derivation on wallet create/import
- #88 — network indicator turns orange while p2p sync is in progress
