### PR TITLE
feat(platform): auto-refresh platform address balances

### DIFF
--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -12,7 +12,7 @@ import { useConnectionModeContext } from "@renderer/contexts/ConnectionModeConte
 import { useFiat } from "@renderer/hooks/useFiat";
 import { useWalletBalance, refreshBalance } from "@renderer/hooks/useWalletBalance";
 import { refreshTransactions } from "@renderer/hooks/useWalletTransactions";
-import { usePlatformAddresses, prefetchPlatformAddresses } from "@renderer/hooks/usePlatformAddresses";
+import { usePlatformAddresses, refreshPlatformAddresses } from "@renderer/hooks/usePlatformAddresses";
 import { useAdresses } from "@renderer/hooks/useAdresses";
 import { useIdentities, prefetchIdentities } from "@renderer/hooks/useIdentities";
 import { useShieldedStatus, useShieldedSyncState } from "@renderer/hooks/useShielded";
@@ -343,7 +343,7 @@ export default function TransferHub(): React.JSX.Element {
     setAcked(false)
     setWizardKey(k => k + 1)
     if (walletId) {
-      prefetchPlatformAddresses(walletId)
+      refreshPlatformAddresses(walletId)
       prefetchIdentities(walletId)
     }
   }

--- a/src/renderer/src/hooks/usePlatformAddresses.ts
+++ b/src/renderer/src/hooks/usePlatformAddresses.ts
@@ -1,6 +1,7 @@
 import { API } from '@renderer/api'
 import { PlatformAddressDto } from '@renderer/api/types'
-import { prefetchAsyncCache, useAsyncWithCache } from './useAsyncWithCache'
+import { BALANCE_REFRESH_MS } from '@renderer/constants'
+import { invalidateAsyncCache, prefetchAsyncCache, useAsyncWithCache } from './useAsyncWithCache'
 
 const fetchPlatformAddresses = (walletId: string): Promise<PlatformAddressDto[]> =>
   API.getPlatformAddresses(walletId).then((d) => (d ?? []) as PlatformAddressDto[])
@@ -11,11 +12,16 @@ export function usePlatformAddresses(walletId: string | undefined) {
     walletId,
     () => fetchPlatformAddresses(walletId!),
     [],
-    { errorMessage: 'Failed to load platform addresses' }
+    { errorMessage: 'Failed to load platform addresses', refreshIntervalMs: BALANCE_REFRESH_MS }
   )
   return { platformAddresses: data, loading, err }
 }
 
 export function prefetchPlatformAddresses(walletId: string): Promise<void> {
   return prefetchAsyncCache('platformAddresses', walletId, () => fetchPlatformAddresses(walletId))
+}
+
+export function refreshPlatformAddresses(walletId: string): Promise<void> {
+  invalidateAsyncCache('platformAddresses', walletId)
+  return prefetchPlatformAddresses(walletId)
 }


### PR DESCRIPTION
Platform (L2) address balances never auto-refreshed — they only updated on a cold mount, the Refresh button, or an explicit invalidate. Identity credits already polled every 30s, so the combined figure in `usePlatformCredits` drifted.

- `usePlatformAddresses` now passes `refreshIntervalMs: BALANCE_REFRESH_MS` (30s), reusing the existing timer machinery in `useAsyncWithCache`.
- Added `refreshPlatformAddresses` (invalidate + prefetch) and used it in `TransferHub.resetForm`, where `prefetchPlatformAddresses` was a no-op on a warm cache — balances stayed stale after a successful transfer.

Typechecks (node/web/tests) and `electron-vite build` pass. `tests/unit/networkStatus.test.ts` fails on this branch's base — master lacks the `@renderer` vitest alias fix; unrelated to this change.