### PR TITLE
implement fee calculation ipc

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "knex": "^3.1.0",
     "react-qr-code": "^2.0.18",
     "react-router-dom": "7.12.0",
-    "sqlite3": "^5.1.7",
+    "sqlite3": "^6.0.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "classic-level": "^3.0.0",
     "dash-core-p2p": "https://github.com/pshenmic/dash-core-p2p#0121cf0eb934ff7378cf7aa42ec13f2907a7eb50",
     "dash-core-sdk": "1.1.3-dev.4",
-    "dash-platform-sdk": "1.5.0-dev.8",
+    "dash-platform-sdk": "1.5.0-dev.9",
     "dash-ui-kit": "1.0.94",
     "electron-log": "^5.4.4",
     "knex": "^3.1.0",

--- a/src/main/platform/PlatformService.ts
+++ b/src/main/platform/PlatformService.ts
@@ -5,6 +5,7 @@ import {SdkSource} from './types/sdk'
 import {Network} from '../src/types'
 import {OperationContext} from './operations/types'
 import {nodeStatus} from './operations/nodeStatus'
+import {transitionFee} from './operations/fee'
 import {addressInfos} from './operations/address/infos'
 import {addressTransfer} from './operations/address/transfer'
 import {addressWithdrawal} from './operations/address/withdrawal'
@@ -197,6 +198,7 @@ export class PlatformService {
       case 'addressFundingFromAssetLock': return addressFundingFromAssetLock(request.payload, ctx)
       case 'identityCreateFromAssetLock': return identityCreateFromAssetLock(request.payload, ctx)
       case 'identityTopUpFromAssetLock': return identityTopUpFromAssetLock(request.payload, ctx)
+      case 'transitionFee': return transitionFee(request.payload, ctx)
       case 'addressInfos': return addressInfos(request.payload, ctx)
       case 'addressTransfer': return addressTransfer(request.payload, ctx)
       case 'addressWithdrawal': return addressWithdrawal(request.payload, ctx)

--- a/src/main/platform/constants.ts
+++ b/src/main/platform/constants.ts
@@ -15,6 +15,13 @@ export const CONSENSUS_DATA = /data:\s*([A-Za-z0-9+/=]+)\s*$/
 
 export const IDENTITY_KEY_LOOKAHEAD = 20
 
+// A fee quote prices the shape of a transition, not its contents, but an
+// identityCreate still needs a key that parses. The secp256k1 generator is the
+// safest stand-in — real point, no derivation, and it never leaves the quote.
+export const FEE_QUOTE_PUBLIC_KEY = Uint8Array.from(
+  Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex'),
+)
+
 export const KEY_SPECS: Array<{purpose: 'AUTHENTICATION' | 'TRANSFER'; securityLevel: 'MASTER' | 'HIGH' | 'CRITICAL'}> = [
   {purpose: 'AUTHENTICATION', securityLevel: 'MASTER'},
   {purpose: 'AUTHENTICATION', securityLevel: 'HIGH'},
@@ -58,6 +65,7 @@ export function laneFor(request: PlatformRequestMessage): string | null {
     case 'identityWithdrawal':
       return `${request.network}:identity:${request.payload.identifier}`
 
+    case 'transitionFee':
     case 'addressInfos':
     case 'identityExists':
     case 'identityBalance':

--- a/src/main/platform/constants.ts
+++ b/src/main/platform/constants.ts
@@ -15,9 +15,8 @@ export const CONSENSUS_DATA = /data:\s*([A-Za-z0-9+/=]+)\s*$/
 
 export const IDENTITY_KEY_LOOKAHEAD = 20
 
-// A fee quote prices the shape of a transition, not its contents, but an
-// identityCreate still needs a key that parses. The secp256k1 generator is the
-// safest stand-in — real point, no derivation, and it never leaves the quote.
+// A quote has no seed, and the fee depends on the key count, not the key. The
+// secp256k1 generator stands in because it parses wherever a real key would.
 export const FEE_QUOTE_PUBLIC_KEY = Uint8Array.from(
   Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex'),
 )

--- a/src/main/platform/constants.ts
+++ b/src/main/platform/constants.ts
@@ -15,8 +15,7 @@ export const CONSENSUS_DATA = /data:\s*([A-Za-z0-9+/=]+)\s*$/
 
 export const IDENTITY_KEY_LOOKAHEAD = 20
 
-// A quote has no seed, and the fee depends on the key count, not the key. The
-// secp256k1 generator stands in because it parses wherever a real key would.
+// Dummy public key for fee calculation
 export const FEE_QUOTE_PUBLIC_KEY = Uint8Array.from(
   Buffer.from('0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798', 'hex'),
 )

--- a/src/main/platform/operations/fee.ts
+++ b/src/main/platform/operations/fee.ts
@@ -1,0 +1,198 @@
+import {
+  AddressCreditWithdrawalTransitionWASM,
+  AddressFundsTransferTransitionWASM,
+  PlatformAddressWASM,
+  ShieldFromAssetLockTransitionWASM,
+  ShieldTransitionWASM,
+} from 'pshenmic-dpp'
+import {
+  AddressFundsFeeStrategyStepWASM,
+  IdentityPublicKeyInCreationWASM,
+  OutputAddressNullableCreditsWASM,
+  OutputAddressWASM,
+  StateTransitionWASM,
+} from 'dash-platform-sdk/types.js'
+import {coreAddressToScript} from '../../src/utils/coreScript'
+import {CORE_FEE_PER_BYTE} from '../../src/constants'
+import {FEE_QUOTE_PUBLIC_KEY, KEY_SPECS} from '../constants'
+import {FeeQuery, PlatformOperations} from '../types/messages'
+import {OperationContext} from './types'
+import {addressInfos} from './address/infos'
+import {DEDUCT_FROM_FIRST, toInputAddresses} from './address/signInputs'
+import {buildAssetLockProof} from './assetLockProof'
+import {minimumFee} from './shielded/spend/fee'
+import {MIN_BUNDLE_ACTIONS} from './shielded/constants'
+
+type Payload = PlatformOperations['transitionFee']['payload']
+type Result = PlatformOperations['transitionFee']['result']
+
+type IdentityQuery = Extract<
+  FeeQuery,
+  {kind: 'identityCreditsToAddresses' | 'identityCreditTransfer' | 'identityWithdrawal'}
+>
+
+type AddressFundedQuery = Extract<
+  FeeQuery,
+  {kind: 'identityCreateFromAddresses' | 'identityTopUpFromAddresses' | 'addressFundingFromAssetLock'}
+>
+
+export async function transitionFee(payload: Payload, ctx: OperationContext): Promise<Result> {
+  const {query} = payload
+
+  const minFeeCredits = await minimumFeeCredits(query, ctx)
+  // Deduped for storage only: the minimum prices one output per recipient, but
+  // two outputs to the same address create one balance entry between them.
+  const recipients = [...new Set(paidAddresses(query))]
+  const newAddresses = await addressesNotInState(recipients, ctx)
+  const storageFeeCredits = PlatformAddressWASM.estimateStorageFeeForNewAddresses(newAddresses.length)
+
+  return {
+    minFeeCredits,
+    storageFeeCredits,
+    totalFeeCredits: minFeeCredits + storageFeeCredits,
+    newAddresses,
+  }
+}
+
+// What consensus will charge, from the protocol implementation itself — the
+// same reason ../shielded/spend/fee.ts exists: these numbers are versioned and
+// scale with the transition's shape, so a constant cannot track them.
+async function minimumFeeCredits(query: FeeQuery, ctx: OperationContext): Promise<bigint> {
+  switch (query.kind) {
+    case 'addressTransfer':
+      return AddressFundsTransferTransitionWASM.estimateMinFee(query.inputCount, query.recipients.length)
+    case 'addressWithdrawal':
+      return AddressCreditWithdrawalTransitionWASM.estimateMinFee(query.inputCount, query.hasChange)
+    case 'shieldedSpend':
+      return minimumFee(query.spendKind, query.noteCount)
+    case 'shield': {
+      const actions = Math.max(query.noteCount, MIN_BUNDLE_ACTIONS)
+      return query.fromAssetLock
+        ? ShieldFromAssetLockTransitionWASM.computeMinimumFee(actions)
+        : ShieldTransitionWASM.computeMinimumFee(actions)
+    }
+    case 'identityCreditsToAddresses':
+    case 'identityCreditTransfer':
+    case 'identityWithdrawal':
+      return (await identityTransition(query, ctx)).calculateMinRequiredFee()
+    case 'identityCreateFromAddresses':
+    case 'identityTopUpFromAddresses':
+    case 'addressFundingFromAssetLock':
+      return addressFundedTransition(query, ctx).calculateMinRequiredFee()
+  }
+}
+
+// Builds exactly what the matching operation builds, minus the signature, and
+// reads the fee off it. The nonce is fetched rather than guessed because it is
+// what the operation will sign over.
+async function identityTransition(query: IdentityQuery, ctx: OperationContext): Promise<StateTransitionWASM> {
+  const {sdk, network} = ctx
+  const identityNonce = await sdk.identities.getIdentityNonce(query.identityId) + 1n
+
+  switch (query.kind) {
+    case 'identityCreditsToAddresses':
+      return sdk.platformAddresses.createStateTransition('identityCreditTransferToAddresses', {
+        identityId: query.identityId,
+        recipients: query.recipients.map(
+          recipient => new OutputAddressWASM(recipient.address, recipient.amountCredits),
+        ),
+        nonce: identityNonce,
+        userFeeIncrease: 0,
+      })
+    case 'identityCreditTransfer':
+      return sdk.identities.createStateTransition('creditTransfer', {
+        identityId: query.identityId,
+        recipientId: query.recipientId,
+        amount: query.amountCredits,
+        identityNonce,
+      })
+    case 'identityWithdrawal':
+      return sdk.identities.createStateTransition('withdrawal', {
+        identityId: query.identityId,
+        amount: query.amountCredits,
+        coreFeePerByte: CORE_FEE_PER_BYTE,
+        pooling: 'Never',
+        identityNonce,
+        outputScript: coreAddressToScript(query.coreAddress, network),
+      })
+  }
+}
+
+// The address-funded three, priced the same way and off the network entirely —
+// their inputs carry the address nonces, so nothing has to be read first.
+// identityCreate is the one query that cannot name its own keys: they come from
+// the seed, which a quote never sees, so it prices the key set this wallet
+// always builds.
+function addressFundedTransition(query: AddressFundedQuery, ctx: OperationContext): StateTransitionWASM {
+  const {sdk} = ctx
+
+  switch (query.kind) {
+    case 'identityCreateFromAddresses':
+      return sdk.platformAddresses.createStateTransition('identityCreateFromAddresses', {
+        publicKeys: KEY_SPECS.map((spec, keyId) =>
+          new IdentityPublicKeyInCreationWASM(
+            keyId, spec.purpose, spec.securityLevel, 'ECDSA_SECP256K1', false, FEE_QUOTE_PUBLIC_KEY)),
+        inputs: toInputAddresses(query.inputs),
+        feeStrategy: DEDUCT_FROM_FIRST,
+        inputWitness: [],
+        userFeeIncrease: 0,
+      })
+    case 'identityTopUpFromAddresses':
+      return sdk.platformAddresses.createStateTransition('identityTopUpFromAddresses', {
+        identityId: query.identityId,
+        inputs: toInputAddresses(query.inputs),
+        feeStrategy: DEDUCT_FROM_FIRST,
+        inputWitness: [],
+        userFeeIncrease: 0,
+      })
+    case 'addressFundingFromAssetLock':
+      return sdk.platformAddresses.createStateTransition('addressFundingFromAssetLock', {
+        assetLockProof: buildAssetLockProof(query.assetLockProof, query.txid, query.outputIndex),
+        inputs: [],
+        feeStrategy: [AddressFundsFeeStrategyStepWASM.ReduceOutput(0)],
+        inputWitness: [],
+        outputs: [new OutputAddressNullableCreditsWASM(query.recipient)],
+        userFeeIncrease: 0,
+      })
+  }
+}
+
+// The platform addresses a transition pays. A payout to a Core address, into
+// the pool or onto an identity balance creates no balance entry, so those kinds
+// are charged no storage. The asset-lock shield's surplusOutput is counted as a
+// payout: dpp states no amount for it, so this assumes the leftover credits
+// land there.
+function paidAddresses(query: FeeQuery): string[] {
+  switch (query.kind) {
+    case 'addressTransfer':
+    case 'shieldedSpend':
+      return query.recipients
+    case 'identityCreditsToAddresses':
+      return query.recipients.map(recipient => recipient.address)
+    case 'shield':
+      return query.surplusAddress != null ? [query.surplusAddress] : []
+    case 'addressFundingFromAssetLock':
+      return [query.recipient]
+    case 'addressWithdrawal':
+    case 'identityCreditTransfer':
+    case 'identityWithdrawal':
+    case 'identityCreateFromAddresses':
+    case 'identityTopUpFromAddresses':
+      return []
+  }
+}
+
+// dash-platform-sdk reports an address missing from state as a zero balance
+// with a zero nonce, so "never funded and never signed" is the only signal a
+// client has for one — the test PlatformAddressService uses to find used
+// addresses, read the other way round.
+async function addressesNotInState(addresses: string[], ctx: OperationContext): Promise<string[]> {
+  if (addresses.length === 0) return []
+
+  const {infos} = await addressInfos({addresses}, ctx)
+  const inState = new Set(
+    infos.filter(info => info.balance > 0n || info.nonce > 0).map(info => info.address),
+  )
+
+  return addresses.filter(address => !inState.has(address))
+}

--- a/src/main/platform/operations/fee.ts
+++ b/src/main/platform/operations/fee.ts
@@ -40,8 +40,7 @@ export async function transitionFee(payload: Payload, ctx: OperationContext): Pr
   const {query} = payload
 
   const minFeeCredits = await minimumFeeCredits(query, ctx)
-  // Deduped for storage only: the minimum prices one output per recipient, but
-  // two outputs to the same address create one balance entry between them.
+  // Deduped for storage only: two outputs to one address create one entry.
   const recipients = [...new Set(paidAddresses(query))]
   const newAddresses = await addressesNotInState(recipients, ctx)
   const storageFeeCredits = PlatformAddressWASM.estimateStorageFeeForNewAddresses(newAddresses.length)
@@ -54,9 +53,6 @@ export async function transitionFee(payload: Payload, ctx: OperationContext): Pr
   }
 }
 
-// What consensus will charge, from the protocol implementation itself — the
-// same reason ../shielded/spend/fee.ts exists: these numbers are versioned and
-// scale with the transition's shape, so a constant cannot track them.
 async function minimumFeeCredits(query: FeeQuery, ctx: OperationContext): Promise<bigint> {
   switch (query.kind) {
     case 'addressTransfer':
@@ -82,9 +78,7 @@ async function minimumFeeCredits(query: FeeQuery, ctx: OperationContext): Promis
   }
 }
 
-// Builds exactly what the matching operation builds, minus the signature, and
-// reads the fee off it. The nonce is fetched rather than guessed because it is
-// what the operation will sign over.
+// Unsigned: the fee does not depend on the signature, so a quote needs no seed.
 async function identityTransition(query: IdentityQuery, ctx: OperationContext): Promise<StateTransitionWASM> {
   const {sdk, network} = ctx
   const identityNonce = await sdk.identities.getIdentityNonce(query.identityId) + 1n
@@ -118,11 +112,7 @@ async function identityTransition(query: IdentityQuery, ctx: OperationContext): 
   }
 }
 
-// The address-funded three, priced the same way and off the network entirely —
-// their inputs carry the address nonces, so nothing has to be read first.
-// identityCreate is the one query that cannot name its own keys: they come from
-// the seed, which a quote never sees, so it prices the key set this wallet
-// always builds.
+// The inputs carry their own nonces, so none of these read the network.
 function addressFundedTransition(query: AddressFundedQuery, ctx: OperationContext): StateTransitionWASM {
   const {sdk} = ctx
 
@@ -157,11 +147,8 @@ function addressFundedTransition(query: AddressFundedQuery, ctx: OperationContex
   }
 }
 
-// The platform addresses a transition pays. A payout to a Core address, into
-// the pool or onto an identity balance creates no balance entry, so those kinds
-// are charged no storage. The asset-lock shield's surplusOutput is counted as a
-// payout: dpp states no amount for it, so this assumes the leftover credits
-// land there.
+// A payout to a Core address, the pool or an identity balance creates no entry.
+// surplusOutput is counted as a payout — dpp states no amount for it.
 function paidAddresses(query: FeeQuery): string[] {
   switch (query.kind) {
     case 'addressTransfer':
@@ -183,9 +170,7 @@ function paidAddresses(query: FeeQuery): string[] {
 }
 
 // dash-platform-sdk reports an address missing from state as a zero balance
-// with a zero nonce, so "never funded and never signed" is the only signal a
-// client has for one — the test PlatformAddressService uses to find used
-// addresses, read the other way round.
+// with a zero nonce, so that pair is the only signal a client gets.
 async function addressesNotInState(addresses: string[], ctx: OperationContext): Promise<string[]> {
   if (addresses.length === 0) return []
 

--- a/src/main/platform/types/messages.ts
+++ b/src/main/platform/types/messages.ts
@@ -78,6 +78,42 @@ export interface Recipient {
   amountCredits: bigint
 }
 
+// What a transition costs before it exists. The first four kinds have a static
+// estimator in dpp and are pure arithmetic; the last three have none, so the
+// quote builds the transition and asks it — which is why they carry the same
+// fields their operation does. Everything here is public: a quote never takes
+// the seed, because the fee does not depend on the signature.
+export type FeeQuery =
+  | {kind: 'addressTransfer'; inputCount: number; recipients: string[]}
+  | {kind: 'addressWithdrawal'; inputCount: number; hasChange: boolean}
+  | {kind: 'shieldedSpend'; spendKind: SpendKind; noteCount: number; recipients: string[]}
+  // Only the asset-lock shield has a transparent destination besides the pool:
+  // its surplusOutput. The shield from platform addresses has none — leftover
+  // input credits go to the fee strategy, not to a new address.
+  | {kind: 'shield'; noteCount: number; fromAssetLock: boolean; surplusAddress: string | null}
+  | {kind: 'identityCreditsToAddresses'; identityId: string; recipients: Recipient[]}
+  | {kind: 'identityCreditTransfer'; identityId: string; recipientId: string; amountCredits: bigint}
+  | {kind: 'identityWithdrawal'; identityId: string; amountCredits: bigint; coreAddress: string}
+  | {kind: 'identityCreateFromAddresses'; inputs: AddressInput[]}
+  | {kind: 'identityTopUpFromAddresses'; identityId: string; inputs: AddressInput[]}
+  | {
+      kind: 'addressFundingFromAssetLock'
+      assetLockProof: AssetLockProofParams
+      txid: string
+      outputIndex: number
+      recipient: string
+    }
+
+// A recipient that is not in state yet has its balance entry created by this
+// transition, and GroveDB charges that storage on top of the minimum — which
+// is why the first payment to an address costs more than every later one.
+export interface FeeQuote {
+  minFeeCredits: bigint
+  storageFeeCredits: bigint
+  totalFeeCredits: bigint
+  newAddresses: string[]
+}
+
 export type AssetLockProofParams =
   | {type: 'chainLock'; coreChainLockedHeight: number}
   | {type: 'instantLock'; instantLock: string; transaction: string}
@@ -145,6 +181,10 @@ export interface PlatformOperations {
   identityTopUpFromAssetLock: {
     payload: AssetLockFunded & {identifier: string}
     result: {stHash: string}
+  }
+  transitionFee: {
+    payload: {query: FeeQuery}
+    result: FeeQuote
   }
   addressInfos: {
     payload: {addresses: string[]}

--- a/src/main/platform/types/messages.ts
+++ b/src/main/platform/types/messages.ts
@@ -78,18 +78,13 @@ export interface Recipient {
   amountCredits: bigint
 }
 
-// What a transition costs before it exists. The first four kinds have a static
-// estimator in dpp and are pure arithmetic; the last three have none, so the
-// quote builds the transition and asks it — which is why they carry the same
-// fields their operation does. Everything here is public: a quote never takes
-// the seed, because the fee does not depend on the signature.
+// Kinds without a static estimator in dpp carry what their operation builds
+// with, because the quote has to build the transition to price it.
 export type FeeQuery =
   | {kind: 'addressTransfer'; inputCount: number; recipients: string[]}
   | {kind: 'addressWithdrawal'; inputCount: number; hasChange: boolean}
   | {kind: 'shieldedSpend'; spendKind: SpendKind; noteCount: number; recipients: string[]}
-  // Only the asset-lock shield has a transparent destination besides the pool:
-  // its surplusOutput. The shield from platform addresses has none — leftover
-  // input credits go to the fee strategy, not to a new address.
+  // Only the asset-lock shield has a transparent destination besides the pool.
   | {kind: 'shield'; noteCount: number; fromAssetLock: boolean; surplusAddress: string | null}
   | {kind: 'identityCreditsToAddresses'; identityId: string; recipients: Recipient[]}
   | {kind: 'identityCreditTransfer'; identityId: string; recipientId: string; amountCredits: bigint}
@@ -104,9 +99,8 @@ export type FeeQuery =
       recipient: string
     }
 
-// A recipient that is not in state yet has its balance entry created by this
-// transition, and GroveDB charges that storage on top of the minimum — which
-// is why the first payment to an address costs more than every later one.
+// storageFeeCredits is what creating newAddresses' balance entries costs, which
+// is why a first payment to an address is dearer than every later one.
 export interface FeeQuote {
   minFeeCredits: bigint
   storageFeeCredits: bigint

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -34,6 +34,7 @@ import {SetAddressLabel} from "./api/wallet/setAddressLabel";
 import {SetWalletLabel} from "./api/wallet/setWalletLabel";
 import {SendTransactionHandler} from "./api/wallet/sendTransaction";
 import {GetTxLockStatusHandler} from "./api/wallet/getTxLockStatus";
+import {EstimateTransitionFeeHandler} from "./api/wallet/estimateTransitionFee";
 import {SendPlatformTransferHandler} from "./api/wallet/sendPlatformTransfer";
 import {TopUpIdentityFromAddressesHandler} from "./api/wallet/topUpIdentityFromAddresses";
 import {WithdrawPlatformCreditsHandler} from "./api/wallet/withdrawPlatformCredits";
@@ -134,6 +135,7 @@ export class WalletBackend {
     ipcMain.handle('setWalletLabel', new SetWalletLabel(this.walletService).handle)
     ipcMain.handle('sendTransaction', new SendTransactionHandler(this.walletService).handle)
     ipcMain.handle('getTxLockStatus', new GetTxLockStatusHandler(this.walletService).handle)
+    ipcMain.handle('estimateTransitionFee', new EstimateTransitionFeeHandler(this.platformAddressService).handle)
     ipcMain.handle('sendPlatformTransfer', new SendPlatformTransferHandler(this.platformAddressService).handle)
     ipcMain.handle('topUpIdentityFromAddresses', new TopUpIdentityFromAddressesHandler(this.platformAddressService).handle)
     ipcMain.handle('withdrawPlatformCredits', new WithdrawPlatformCreditsHandler(this.platformAddressService).handle)

--- a/src/main/src/api/wallet/estimateTransitionFee.ts
+++ b/src/main/src/api/wallet/estimateTransitionFee.ts
@@ -1,0 +1,21 @@
+import { IpcMainInvokeEvent } from 'electron/utility'
+import { PlatformAddressService } from '../../services/PlatformAddressService'
+import { Network } from '../../types'
+import { TransitionFeeEstimate } from '../../types/TransitionFee'
+import { FeeQuery } from '../../../platform/types/messages'
+
+export class EstimateTransitionFeeHandler {
+  private platformAddressService: PlatformAddressService
+
+  constructor(platformAddressService: PlatformAddressService) {
+    this.platformAddressService = platformAddressService
+  }
+
+  handle = async (
+    _event: IpcMainInvokeEvent,
+    network: Network,
+    query: FeeQuery,
+  ): Promise<TransitionFeeEstimate> => {
+    return this.platformAddressService.estimateTransitionFee(network, query)
+  }
+}

--- a/src/main/src/services/PlatformAddressService.ts
+++ b/src/main/src/services/PlatformAddressService.ts
@@ -408,8 +408,7 @@ export class PlatformAddressService {
       amountCredits,
     })
 
-    this.shielded.checkForNewNotes(network).catch(e =>
-      console.error('Failed to refresh the shielded pool after a shield', e))
+    void this.shielded.refreshNotes(walletId, network, seed)
 
     return {
       stHash,

--- a/src/main/src/services/PlatformAddressService.ts
+++ b/src/main/src/services/PlatformAddressService.ts
@@ -25,7 +25,8 @@ import {
   WITHDRAWAL_FEE_CREDITS,
 } from '../constants'
 import {identityPath} from '../utils/identityKeys'
-import {AddressInput} from '../../platform/types/messages'
+import {AddressInput, FeeQuery} from '../../platform/types/messages'
+import {TransitionFeeEstimate} from '../types/TransitionFee'
 import {selectPlatformSource, selectPlatformInputsWithFee, topUpFeeCredits, identityTransferFeeCredits, identityCreateFeeCredits} from '../utils/platformTransfer'
 import {AcquiredAssetLock, AssetLockFundingRow} from '../types/AssetLock'
 import {PlatformSourceCandidate} from '../types/PlatformTransfer'
@@ -90,6 +91,17 @@ export class PlatformAddressService {
     await this.walletDAO.setPlatformAddressCount(walletId, count + 1)
 
     return this.getPlatformAddresses(walletId)
+  }
+
+  async estimateTransitionFee(network: Network, query: FeeQuery): Promise<TransitionFeeEstimate> {
+    const quote = await this.platform.request('transitionFee', network, {query})
+
+    return {
+      minFeeCredits: quote.minFeeCredits.toString(),
+      storageFeeCredits: quote.storageFeeCredits.toString(),
+      totalFeeCredits: quote.totalFeeCredits.toString(),
+      newAddresses: quote.newAddresses,
+    }
   }
 
   async sendPlatformTransfer(

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -223,65 +223,96 @@ export class ShieldedService {
     return this.syncStates.get(walletId) ?? this.idleSyncState()
   }
 
-  async startSync(walletId: string, password: string): Promise<ShieldedSyncState> {
+  // Returns the in-flight state when a sync is already running for this wallet,
+  // otherwise installs a fresh one.
+  private beginSync(walletId: string): {state: ShieldedSyncState; running: boolean} {
     const current = this.syncStates.get(walletId)
     if (current != null && (current.phase === 'syncing' || current.phase === 'recovering')) {
-      return current
+      return {state: current, running: true}
     }
-
     const state: ShieldedSyncState = {
       phase: 'syncing', fetched: 0, total: 0, balance: null, notes: [], error: null, syncedAt: null
     }
     this.syncStates.set(walletId, state)
+    return {state, running: false}
+  }
+
+  async startSync(walletId: string, password: string): Promise<ShieldedSyncState> {
+    const {state, running} = this.beginSync(walletId)
+    if (running) return state
 
     try {
       const {wallet: {network}, seed} = await unlockWallet(this.walletDAO, walletId, password)
       await this.cacheAddresses(walletId, seed, network)
-      await this.checkForNewNotes(network, (fetched, total) => {
-        state.fetched = fetched
-        state.total = total
-      })
-
-      const priorNotes = await this.shieldedNoteDAO.getOwnedNotes(walletId)
-      const decodedFrom = await this.walletDAO.getShieldedDecodedCount(walletId)
-      const fresh = await this.shieldedPoolDAO.getEncryptedNotesFrom(network, decodedFrom)
-      
-      const owned = await this.shieldedPoolDAO.getEncryptedNotes(network, priorNotes.map(note => note.index))
-      const notes = [...owned, ...fresh]
-
-      if (notes.length === 0) {
-        state.balance = '0'
-        state.phase = 'done'
-        state.syncedAt = Date.now()
-        return state
-      }
-
-      const decodedUpTo = fresh.length > 0 ? fresh[fresh.length - 1].index + 1 : decodedFrom
-      this.platform.request('sync', network, {seed, notes}, {
-        onProgress: phase => { state.phase = syncPhase(phase) ?? state.phase },
-      }).then(async result => {
-        const all: ShieldedNoteInfo[] = result.notes.map(note => ({
-          index: note.index,
-          amount: note.amount.toString(),
-          spent: note.spent,
-          address: note.address,
-        })).sort((a, b) => b.index - a.index)
-        let balance = 0n
-        for (const note of all) {
-          if (!note.spent) balance += BigInt(note.amount)
-        }
-        state.balance = balance.toString()
-        state.notes = all
-        state.phase = 'done'
-        state.syncedAt = Date.now()
-        await this.shieldedNoteDAO.upsertNotes(walletId, all)
-        await this.walletDAO.setShieldedDecodedCount(walletId, decodedUpTo)
-      }).catch(e => this.failed(state, e))
+      this.syncNotes(walletId, network, seed, state).catch(e => this.failed(state, e))
     } catch (e) {
-      state.phase = 'error'
-      state.error = e instanceof Error ? e.message : String(e)
+      this.failed(state, e)
     }
     return state
+  }
+
+  // A spend's change note and a shield's new note are indistinguishable from
+  // anyone else's until they are trial-decrypted, so a refresh that holds no
+  // seed leaves the balance stale and the note list short. Never rejects: the
+  // outcome belongs to the sync state, and callers run inside jobs that would
+  // otherwise report their own success as a failure.
+  async refreshNotes(walletId: string, network: Network, seed: Uint8Array): Promise<void> {
+    const {state, running} = this.beginSync(walletId)
+    if (running) return
+
+    try {
+      await this.syncNotes(walletId, network, seed, state)
+    } catch (e) {
+      this.failed(state, e)
+    }
+  }
+
+  private async syncNotes(
+    walletId: string,
+    network: Network,
+    seed: Uint8Array,
+    state: ShieldedSyncState,
+  ): Promise<void> {
+    await this.checkForNewNotes(network, (fetched, total) => {
+      state.fetched = fetched
+      state.total = total
+    })
+
+    const priorNotes = await this.shieldedNoteDAO.getOwnedNotes(walletId)
+    const decodedFrom = await this.walletDAO.getShieldedDecodedCount(walletId)
+    const fresh = await this.shieldedPoolDAO.getEncryptedNotesFrom(network, decodedFrom)
+
+    const owned = await this.shieldedPoolDAO.getEncryptedNotes(network, priorNotes.map(note => note.index))
+    const notes = [...owned, ...fresh]
+
+    if (notes.length === 0) {
+      state.balance = '0'
+      state.phase = 'done'
+      state.syncedAt = Date.now()
+      return
+    }
+
+    const decodedUpTo = fresh.length > 0 ? fresh[fresh.length - 1].index + 1 : decodedFrom
+    const result = await this.platform.request('sync', network, {seed, notes}, {
+      onProgress: phase => { state.phase = syncPhase(phase) ?? state.phase },
+    })
+
+    const all: ShieldedNoteInfo[] = result.notes.map(note => ({
+      index: note.index,
+      amount: note.amount.toString(),
+      spent: note.spent,
+      address: note.address,
+    })).sort((a, b) => b.index - a.index)
+    let balance = 0n
+    for (const note of all) {
+      if (!note.spent) balance += BigInt(note.amount)
+    }
+    state.balance = balance.toString()
+    state.notes = all
+    state.phase = 'done'
+    state.syncedAt = Date.now()
+    await this.shieldedNoteDAO.upsertNotes(walletId, all)
+    await this.walletDAO.setShieldedDecodedCount(walletId, decodedUpTo)
   }
 
   private idleSpendState(): ShieldedSpendState {
@@ -373,8 +404,7 @@ export class ShieldedService {
       state.stHash = result.stHash
       state.identityId = result.identityId
       state.phase = 'done'
-      this.checkForNewNotes(network).catch(e =>
-        console.error('Failed to refresh the shielded pool after a spend', e))
+      void this.refreshNotes(walletId, network, payload.seed)
       if (identityCreate != null && result.identityId != null) {
         this.persistCreatedIdentity({walletId, network, ...identityCreate}, result.identityId).catch(e =>
           console.error('Failed to persist identity created from the shielded pool', e))
@@ -439,7 +469,7 @@ export class ShieldedService {
         const acquired = await this.assetLock.acquire(state, {
           walletId, kind: 'shielded', destination, amountDuffs, seed,
         })
-        await this.settleShield(seed, network, state, acquired)
+        await this.settleShield(walletId, seed, network, state, acquired)
       })
     } catch (error) {
       zeroSeed(unlocked)
@@ -454,7 +484,7 @@ export class ShieldedService {
     const state = this.assetLock.resume(walletId, row)
     return this.runFunding(state, unlocked, async () => {
       const acquired = await this.assetLock.reacquire(state, row)
-      await this.settleShield(seed, network, state, acquired)
+      await this.settleShield(walletId, seed, network, state, acquired)
     })
   }
 
@@ -468,6 +498,7 @@ export class ShieldedService {
   }
 
   private async settleShield(
+    walletId: string,
     seed: Uint8Array,
     network: Network,
     state: AssetLockFundingState,
@@ -488,8 +519,8 @@ export class ShieldedService {
     })
 
     await this.assetLock.done(state, row.txid, stHash)
-    this.checkForNewNotes(network).catch(e =>
-      console.error('Failed to refresh the shielded pool after a shield', e))
+    // Awaited: runFunding zeroes the seed the moment this settles.
+    await this.refreshNotes(walletId, network, seed)
   }
 
   private async markNotesSpent(walletId: string, indexes: number[]): Promise<void> {

--- a/src/main/src/services/ShieldedService.ts
+++ b/src/main/src/services/ShieldedService.ts
@@ -267,6 +267,17 @@ export class ShieldedService {
     }
   }
 
+  private settleSync(state: ShieldedSyncState, notes: ShieldedNoteInfo[]): void {
+    let balance = 0n
+    for (const note of notes) {
+      if (!note.spent) balance += BigInt(note.amount)
+    }
+    state.balance = balance.toString()
+    state.notes = notes
+    state.phase = 'done'
+    state.syncedAt = Date.now()
+  }
+
   private async syncNotes(
     walletId: string,
     network: Network,
@@ -282,18 +293,14 @@ export class ShieldedService {
     const decodedFrom = await this.walletDAO.getShieldedDecodedCount(walletId)
     const fresh = await this.shieldedPoolDAO.getEncryptedNotesFrom(network, decodedFrom)
 
-    const owned = await this.shieldedPoolDAO.getEncryptedNotes(network, priorNotes.map(note => note.index))
-    const notes = [...owned, ...fresh]
-
-    if (notes.length === 0) {
-      state.balance = '0'
-      state.phase = 'done'
-      state.syncedAt = Date.now()
+    if (fresh.length === 0) {
+      this.settleSync(state, priorNotes)
       return
     }
 
-    const decodedUpTo = fresh.length > 0 ? fresh[fresh.length - 1].index + 1 : decodedFrom
-    const result = await this.platform.request('sync', network, {seed, notes}, {
+    const owned = await this.shieldedPoolDAO.getEncryptedNotes(network, priorNotes.map(note => note.index))
+    const decodedUpTo = fresh[fresh.length - 1].index + 1
+    const result = await this.platform.request('sync', network, {seed, notes: [...owned, ...fresh]}, {
       onProgress: phase => { state.phase = syncPhase(phase) ?? state.phase },
     })
 
@@ -303,14 +310,7 @@ export class ShieldedService {
       spent: note.spent,
       address: note.address,
     })).sort((a, b) => b.index - a.index)
-    let balance = 0n
-    for (const note of all) {
-      if (!note.spent) balance += BigInt(note.amount)
-    }
-    state.balance = balance.toString()
-    state.notes = all
-    state.phase = 'done'
-    state.syncedAt = Date.now()
+    this.settleSync(state, all)
     await this.shieldedNoteDAO.upsertNotes(walletId, all)
     await this.walletDAO.setShieldedDecodedCount(walletId, decodedUpTo)
   }

--- a/src/main/src/types/TransitionFee.ts
+++ b/src/main/src/types/TransitionFee.ts
@@ -1,0 +1,6 @@
+export interface TransitionFeeEstimate {
+  minFeeCredits: string
+  storageFeeCredits: string
+  totalFeeCredits: string
+  newAddresses: string[]
+}

--- a/src/preload/definitions.ts
+++ b/src/preload/definitions.ts
@@ -25,6 +25,7 @@ export const apiDefinitions = (ipcRenderer) => ({
   setWalletLabel: (walletId: string, label: string | null) => ipcRenderer.invoke('setWalletLabel', walletId, label),
   sendTransaction: (walletId: string, toAddress: string, amountDuffs: string, password: string, fromAddress?: string) => ipcRenderer.invoke('sendTransaction', walletId, toAddress, amountDuffs, password, fromAddress),
   getTxLockStatus: (walletId: string, txid: string) => ipcRenderer.invoke('getTxLockStatus', walletId, txid),
+  estimateTransitionFee: (network: 'mainnet' | 'testnet', query: unknown) => ipcRenderer.invoke('estimateTransitionFee', network, query),
   sendPlatformTransfer: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('sendPlatformTransfer', walletId, fromAddress, toAddress, amountCredits, password),
   topUpIdentityFromAddresses: (walletId: string, identityId: string, fromAddress: string | null, amountCredits: string, password: string) => ipcRenderer.invoke('topUpIdentityFromAddresses', walletId, identityId, fromAddress, amountCredits, password),
   withdrawPlatformCredits: (walletId: string, fromAddress: string | null, toCoreAddress: string, amountCredits: string, password: string) => ipcRenderer.invoke('withdrawPlatformCredits', walletId, fromAddress, toCoreAddress, amountCredits, password),

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -31,6 +31,7 @@ declare global {
       setWalletLabel: (walletId: string, label: string | null) => Promise<{ success: boolean; errorMessage: string | null }>
       sendTransaction: (walletId: string, toAddress: string, amountDuffs: string, password: string, fromAddress?: string) => Promise<unknown>
       getTxLockStatus: (walletId: string, txid: string) => Promise<unknown>
+      estimateTransitionFee: (network: 'mainnet' | 'testnet', query: unknown) => Promise<{ minFeeCredits: string; storageFeeCredits: string; totalFeeCredits: string; newAddresses: string[] }>
       sendPlatformTransfer: (walletId: string, fromAddress: string, toAddress: string, amountCredits: string, password: string) => Promise<unknown>
       topUpIdentityFromAddresses: (walletId: string, identityId: string, fromAddress: string | null, amountCredits: string, password: string) => Promise<unknown>
       withdrawPlatformCredits: (walletId: string, fromAddress: string | null, toCoreAddress: string, amountCredits: string, password: string) => Promise<unknown>

--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -1,4 +1,4 @@
-import { AssetLockFundingKind, AssetLockFundingState, ConnectionType, Contact, ExchangeRatesResult, IdentityCreateResult, Network, PlatformAddressDto, PlatformSendResult, PreferencesJSON, QueryStatus, SendResult, ShieldResult, ShieldedNotesInfo, ShieldedPoolInfo, ShieldedSpendState, ShieldedStatus, ShieldedSyncState, TxLockStatus } from './types'
+import { AssetLockFundingKind, AssetLockFundingState, ConnectionType, Contact, ExchangeRatesResult, IdentityCreateResult, Network, PlatformAddressDto, PlatformSendResult, PreferencesJSON, QueryStatus, SendResult, ShieldResult, ShieldedNotesInfo, ShieldedPoolInfo, ShieldedSpendState, ShieldedStatus, ShieldedSyncState, TransitionFeeDto, TransitionFeeQuery, TxLockStatus } from './types'
 
 export class API {
   private static get api() {
@@ -75,6 +75,10 @@ export class API {
 
   static async addPlatformAddress(walletId: string): Promise<PlatformAddressDto[]> {
     return this.api.addPlatformAddress(walletId) as Promise<PlatformAddressDto[]>
+  }
+
+  static async estimateTransitionFee(network: Network, query: TransitionFeeQuery): Promise<TransitionFeeDto> {
+    return this.api.estimateTransitionFee(network, query) as Promise<TransitionFeeDto>
   }
 
   static async deleteWallet(walletId: string) {

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -34,6 +34,41 @@ export interface PlatformAddressDto {
   nonce: number
 }
 
+// estimateTransitionFee
+export interface TransitionFeeInput {
+  platformAddress: string
+  index: number
+  nonce: number
+  credits: bigint
+}
+
+export type TransitionFeeQuery =
+  | { kind: 'addressTransfer'; inputCount: number; recipients: string[] }
+  | { kind: 'addressWithdrawal'; inputCount: number; hasChange: boolean }
+  | { kind: 'shieldedSpend'; spendKind: 'transfer' | 'unshield' | 'withdrawal' | 'identityCreate'; noteCount: number; recipients: string[] }
+  | { kind: 'shield'; noteCount: number; fromAssetLock: boolean; surplusAddress: string | null }
+  | { kind: 'identityCreditsToAddresses'; identityId: string; recipients: { address: string; amountCredits: bigint }[] }
+  | { kind: 'identityCreditTransfer'; identityId: string; recipientId: string; amountCredits: bigint }
+  | { kind: 'identityWithdrawal'; identityId: string; amountCredits: bigint; coreAddress: string }
+  | { kind: 'identityCreateFromAddresses'; inputs: TransitionFeeInput[] }
+  | { kind: 'identityTopUpFromAddresses'; identityId: string; inputs: TransitionFeeInput[] }
+  | {
+      kind: 'addressFundingFromAssetLock'
+      assetLockProof: { type: 'chainLock'; coreChainLockedHeight: number } | { type: 'instantLock'; instantLock: string; transaction: string }
+      txid: string
+      outputIndex: number
+      recipient: string
+    }
+
+// newAddresses are the recipients storageFeeCredits was charged for — the ones
+// this transition would create in state.
+export interface TransitionFeeDto {
+  minFeeCredits: string
+  storageFeeCredits: string
+  totalFeeCredits: string
+  newAddresses: string[]
+}
+
 // getStatus
 export type Network = 'mainnet' | 'testnet'
 

--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -60,8 +60,6 @@ export type TransitionFeeQuery =
       recipient: string
     }
 
-// newAddresses are the recipients storageFeeCredits was charged for — the ones
-// this transition would create in state.
 export interface TransitionFeeDto {
   minFeeCredits: string
   storageFeeCredits: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -2987,10 +2987,10 @@ dash-core-sdk@1.1.3-dev.4:
     typescript "^5.9.2"
     ws "^8.18.3"
 
-dash-platform-sdk@1.5.0-dev.8:
-  version "1.5.0-dev.8"
-  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.5.0-dev.8.tgz#1b9d8b1c08a55f973d6b37008dc2305e148f8b5c"
-  integrity sha512-aAIpIPQfJ5X1eq8SSiBIVoDEEJDeSB4M8FTdkDqUJgGKiQfZeADZ/lMWHHkvq9b5QbzPzdHMMg9Uw5NBqqJzIg==
+dash-platform-sdk@1.5.0-dev.9:
+  version "1.5.0-dev.9"
+  resolved "https://registry.yarnpkg.com/dash-platform-sdk/-/dash-platform-sdk-1.5.0-dev.9.tgz#ca709366bc81c6e83d54604e9e45908d84df7804"
+  integrity sha512-vJ8K1NK8Tp3F3Ka3midMAEseRj11lwyaEb9XU5n6Ta0WRhe4umFNHFZfliEti2PWs/vmn7HX39a+eXAGQ7/E2A==
   dependencies:
     "@bufbuild/protobuf" "^2.6.0"
     "@protobuf-ts/grpcweb-transport" "^2.11.1"
@@ -2999,7 +2999,7 @@ dash-platform-sdk@1.5.0-dev.8:
     "@scure/bip39" "^2.0.0"
     "@scure/btc-signer" "^2.0.1"
     cbor-x "^1.6.0"
-    pshenmic-dpp "2.0.0-dev.26"
+    pshenmic-dpp "2.0.0-dev.28"
 
 dash-ui-kit@1.0.94:
   version "1.0.94"
@@ -5438,10 +5438,10 @@ protoc@^32.1.0:
   resolved "https://registry.npmjs.org/protoc/-/protoc-32.1.0.tgz"
   integrity sha512-yICJJCGHJLM9ao5W2V4CGp1d7xuBsdHzgVDw6L8mdDtoIcqzN3arNPOm9Jx4Ufp5vfhQfJGkNUDo6mm/SLPdXw==
 
-pshenmic-dpp@2.0.0-dev.26:
-  version "2.0.0-dev.26"
-  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.26.tgz#f7b102ef17eef3b16758a67b8d0e69c8917cbd2e"
-  integrity sha512-Gzk8bsz1abTn/eU5a80S3mr5u4YlI1pLqQrzvpYSSCjiPSXbEatidm0uOK9cyYQ7d3DaFA+HkYB/LxC+KxV0jQ==
+pshenmic-dpp@2.0.0-dev.28:
+  version "2.0.0-dev.28"
+  resolved "https://registry.yarnpkg.com/pshenmic-dpp/-/pshenmic-dpp-2.0.0-dev.28.tgz#3aec944bf9be86fd1faac5d06fb1d5d19974487c"
+  integrity sha512-2nfTDl7jRJ3uANspLkYjFzTMSMBLPUsPS1OezTVEEBFkl86MQ7M6JGlVWF7S4rAUdD0cjYu9NbDMz7jhw9LUNQ==
   dependencies:
     "@emnapi/core" "1.9.0"
     "@emnapi/runtime" "1.9.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,7 +763,7 @@
   resolved "https://registry.npmjs.org/@fontsource/manrope/-/manrope-5.2.8.tgz"
   integrity sha512-gJHJmcuUk7qWcNCfcAri/DJQtXtBYqi9yKratr4jXhSo0I3xUtNNKI+igQIcw5c+m95g0vounk8ZnX/kb8o0TA==
 
-"@gar/promisify@^1.0.1", "@gar/promisify@^1.1.3":
+"@gar/promisify@^1.1.3":
   version "1.1.3"
   resolved "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
@@ -814,6 +814,13 @@
     strip-ansi-cjs "npm:strip-ansi@^6.0.1"
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
+
+"@isaacs/fs-minipass@^4.0.0":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz#2d59ae3ab4b38fb4270bfa23d30f8e2e86c7fe32"
+  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
+  dependencies:
+    minipass "^7.0.4"
 
 "@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
@@ -892,14 +899,6 @@
   resolved "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-3.0.0.tgz"
   integrity sha512-NJBaR352KyIvj3t6sgT/+7xrNyF9Xk9QlLSIqUGVUYlsnDTAUqY8LOmwpcgEx4AMJXRITQ5XEVHD+mMaPfr3mg==
 
-"@npmcli/fs@^1.0.0":
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-1.1.1.tgz"
-  integrity sha512-8KG5RD0GVP4ydEzRn/I4BNDuxDtqVbOdm8675T49OIG/NGhaK0pjPX7ZcDlvKYbA+ulvVK3ztfcF4uBdOxuJbQ==
-  dependencies:
-    "@gar/promisify" "^1.0.1"
-    semver "^7.3.5"
-
 "@npmcli/fs@^2.1.0":
   version "2.1.2"
   resolved "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz"
@@ -907,14 +906,6 @@
   dependencies:
     "@gar/promisify" "^1.1.3"
     semver "^7.3.5"
-
-"@npmcli/move-file@^1.0.1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.1.2.tgz"
-  integrity sha512-1SUf/Cg2GzGDyaf15aR9St9TWlb+XvbZXWpDx8YKs7MLzMH/BCeopv+y9vzrzgkfykCGuWOlSu3mZhj2+FQcrg==
-  dependencies:
-    mkdirp "^1.0.4"
-    rimraf "^3.0.2"
 
 "@npmcli/move-file@^2.0.0":
   version "2.0.1"
@@ -1914,11 +1905,6 @@
     postcss "^8.4.41"
     tailwindcss "4.1.18"
 
-"@tootallnate/once@1":
-  version "1.1.2"
-  resolved "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz"
-  integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
-
 "@tootallnate/once@2":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz"
@@ -2245,10 +2231,15 @@
   resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz"
   integrity sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==
 
-abbrev@1, abbrev@^1.0.0:
+abbrev@^1.0.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz"
   integrity sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+
+abbrev@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-4.0.0.tgz#ec933f0e27b6cd60e89b5c6b2a304af42209bb05"
+  integrity sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==
 
 abstract-level@^3.1.0:
   version "3.1.1"
@@ -2284,7 +2275,7 @@ agent-base@^7.1.0, agent-base@^7.1.2:
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
-agentkeepalive@^4.1.3, agentkeepalive@^4.2.1:
+agentkeepalive@^4.2.1:
   version "4.6.0"
   resolved "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz"
   integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
@@ -2389,19 +2380,6 @@ app-builder-lib@26.0.12:
     tar "^6.1.12"
     temp-file "^3.4.0"
     tiny-async-pool "1.3.0"
-
-"aproba@^1.0.3 || ^2.0.0":
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz"
-  integrity sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==
-
-are-we-there-yet@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz"
-  integrity sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==
-  dependencies:
-    delegates "^1.0.0"
-    readable-stream "^3.6.0"
 
 argparse@^2.0.1:
   version "2.0.1"
@@ -2685,30 +2663,6 @@ cac@^6.7.14:
   resolved "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz"
   integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
 
-cacache@^15.2.0:
-  version "15.3.0"
-  resolved "https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz"
-  integrity sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==
-  dependencies:
-    "@npmcli/fs" "^1.0.0"
-    "@npmcli/move-file" "^1.0.1"
-    chownr "^2.0.0"
-    fs-minipass "^2.0.0"
-    glob "^7.1.4"
-    infer-owner "^1.0.4"
-    lru-cache "^6.0.0"
-    minipass "^3.1.1"
-    minipass-collect "^1.0.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.2"
-    mkdirp "^1.0.3"
-    p-map "^4.0.0"
-    promise-inflight "^1.0.1"
-    rimraf "^3.0.2"
-    ssri "^8.0.1"
-    tar "^6.0.2"
-    unique-filename "^1.1.1"
-
 cacache@^16.1.0:
   version "16.1.3"
   resolved "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz"
@@ -2831,6 +2785,11 @@ chownr@^2.0.0:
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
+chownr@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/chownr/-/chownr-3.0.0.tgz#9855e64ecd240a9cc4267ce8a4aa5d24a1da15e4"
+  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
+
 chromium-pickle-js@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz"
@@ -2921,11 +2880,6 @@ color-name@~1.1.4:
   resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-color-support@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz"
-  integrity sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==
-
 colorette@2.0.19:
   version "2.0.19"
   resolved "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz"
@@ -2965,11 +2919,6 @@ config-file-ts@0.2.8-rc1:
   dependencies:
     glob "^10.3.12"
     typescript "^5.4.3"
-
-console-control-strings@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-  integrity sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==
 
 convert-source-map@^2.0.0:
   version "2.0.0"
@@ -3158,11 +3107,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
-delegates@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-  integrity sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==
-
 detect-libc@^2.0.0, detect-libc@^2.0.1, detect-libc@^2.0.3:
   version "2.1.2"
   resolved "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz"
@@ -3325,7 +3269,7 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-encoding@^0.1.12, encoding@^0.1.13:
+encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -3929,20 +3873,6 @@ functions-have-names@^1.2.3:
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz"
   integrity sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==
 
-gauge@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz"
-  integrity sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==
-  dependencies:
-    aproba "^1.0.3 || ^2.0.0"
-    color-support "^1.1.3"
-    console-control-strings "^1.1.0"
-    has-unicode "^2.0.1"
-    signal-exit "^3.0.7"
-    string-width "^4.2.3"
-    strip-ansi "^6.0.1"
-    wide-align "^1.1.5"
-
 generator-function@^2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz"
@@ -4037,7 +3967,7 @@ glob@^10.3.12:
     package-json-from-dist "^1.0.0"
     path-scurry "^1.11.1"
 
-glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.1.3, glob@^7.1.6:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -4153,11 +4083,6 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-has-unicode@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-  integrity sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==
-
 hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
@@ -4188,15 +4113,6 @@ http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.0:
   version "4.2.0"
   resolved "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz"
   integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
-
-http-proxy-agent@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz"
-  integrity sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
-  dependencies:
-    "@tootallnate/once" "1"
-    agent-base "6"
-    debug "4"
 
 http-proxy-agent@^5.0.0:
   version "5.0.0"
@@ -4566,6 +4482,11 @@ isexe@^2.0.0:
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isexe@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-4.0.0.tgz#48f6576af8e87a18feb796b7ed5e2e5903b43dca"
+  integrity sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==
+
 iterator.prototype@^1.1.5:
   version "1.1.5"
   resolved "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz"
@@ -4886,28 +4807,6 @@ make-fetch-happen@^10.2.1:
     socks-proxy-agent "^7.0.0"
     ssri "^9.0.0"
 
-make-fetch-happen@^9.1.0:
-  version "9.1.0"
-  resolved "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz"
-  integrity sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==
-  dependencies:
-    agentkeepalive "^4.1.3"
-    cacache "^15.2.0"
-    http-cache-semantics "^4.1.0"
-    http-proxy-agent "^4.0.1"
-    https-proxy-agent "^5.0.0"
-    is-lambda "^1.0.1"
-    lru-cache "^6.0.0"
-    minipass "^3.1.3"
-    minipass-collect "^1.0.2"
-    minipass-fetch "^1.3.2"
-    minipass-flush "^1.0.5"
-    minipass-pipeline "^1.2.4"
-    negotiator "^0.6.2"
-    promise-retry "^2.0.1"
-    socks-proxy-agent "^6.0.0"
-    ssri "^8.0.0"
-
 matcher@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz"
@@ -5009,17 +4908,6 @@ minipass-collect@^1.0.2:
   dependencies:
     minipass "^3.0.0"
 
-minipass-fetch@^1.3.2:
-  version "1.4.1"
-  resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-1.4.1.tgz"
-  integrity sha512-CGH1eblLq26Y15+Azk7ey4xh0J/XfJfrCox5LDJiKqI2Q2iwOLOKrlmIaODiSQS8d18jalF6y2K2ePUm0CmShw==
-  dependencies:
-    minipass "^3.1.0"
-    minipass-sized "^1.0.3"
-    minizlib "^2.0.0"
-  optionalDependencies:
-    encoding "^0.1.12"
-
 minipass-fetch@^2.0.3:
   version "2.1.2"
   resolved "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz"
@@ -5038,7 +4926,7 @@ minipass-flush@^1.0.5:
   dependencies:
     minipass "^3.0.0"
 
-minipass-pipeline@^1.2.2, minipass-pipeline@^1.2.4:
+minipass-pipeline@^1.2.4:
   version "1.2.4"
   resolved "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz"
   integrity sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
@@ -5052,7 +4940,7 @@ minipass-sized@^1.0.3:
   dependencies:
     minipass "^3.0.0"
 
-minipass@^3.0.0, minipass@^3.1.0, minipass@^3.1.1, minipass@^3.1.3, minipass@^3.1.6:
+minipass@^3.0.0, minipass@^3.1.1, minipass@^3.1.6:
   version "3.3.6"
   resolved "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz"
   integrity sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==
@@ -5069,13 +4957,25 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
 
-minizlib@^2.0.0, minizlib@^2.1.1, minizlib@^2.1.2:
+minipass@^7.0.4:
+  version "7.1.3"
+  resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.3.tgz#79389b4eb1bb2d003a9bba87d492f2bd37bdc65b"
+  integrity sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==
+
+minizlib@^2.1.1, minizlib@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz"
   integrity sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
   dependencies:
     minipass "^3.0.0"
     yallist "^4.0.0"
+
+minizlib@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-3.1.0.tgz#6ad76c3a8f10227c9b51d1c9ac8e30b27f5a251c"
+  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
+  dependencies:
+    minipass "^7.1.2"
 
 mkdirp-classic@^0.5.2, mkdirp-classic@^0.5.3:
   version "0.5.3"
@@ -5122,7 +5022,7 @@ natural-compare@^1.4.0:
   resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
-negotiator@^0.6.2, negotiator@^0.6.3:
+negotiator@^0.6.3:
   version "0.6.4"
   resolved "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz"
   integrity sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==
@@ -5139,10 +5039,10 @@ node-addon-api@^1.6.3:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-1.7.2.tgz#3df30b95720b53c24e59948b49532b662444f54d"
   integrity sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==
 
-node-addon-api@^7.0.0:
-  version "7.1.1"
-  resolved "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz"
-  integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
+node-addon-api@^8.0.0:
+  version "8.9.1"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-8.9.1.tgz#f40a3c0f087d767e7b2961172158badb3b49697c"
+  integrity sha512-4eUQWVPCUUUiBjLnHS3cXWeC6ryoPUc0U3rP7IuzapoGbzMqd/r6KKO0clr0b+snQhsrueFEhCZDdK+LK7hxKg==
 
 node-api-version@^0.2.0:
   version "0.2.1"
@@ -5163,33 +5063,26 @@ node-gyp-build@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.4.tgz#8a70ee85464ae52327772a90d66c6077a900cfc8"
   integrity sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==
 
-node-gyp@8.x:
-  version "8.4.1"
-  resolved "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz"
-  integrity sha512-olTJRgUtAb/hOXG0E93wZDs5YiJlgbXxTwQAFHyNlRsXQnYzUaF2aGgujZbw+hR8aF4ZG/rST57bWMWD16jr9w==
+node-gyp@12.x:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/node-gyp/-/node-gyp-12.4.0.tgz#2d017b6ea1ca9294dbbee75be533728f49257024"
+  integrity sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw==
   dependencies:
     env-paths "^2.2.0"
-    glob "^7.1.4"
+    exponential-backoff "^3.1.1"
     graceful-fs "^4.2.6"
-    make-fetch-happen "^9.1.0"
-    nopt "^5.0.0"
-    npmlog "^6.0.0"
-    rimraf "^3.0.2"
+    nopt "^9.0.0"
+    proc-log "^6.0.0"
     semver "^7.3.5"
-    tar "^6.1.2"
-    which "^2.0.2"
+    tar "^7.5.4"
+    tinyglobby "^0.2.12"
+    undici "^6.25.0"
+    which "^6.0.0"
 
 node-releases@^2.0.27:
   version "2.0.27"
   resolved "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz"
   integrity sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==
-
-nopt@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz"
-  integrity sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
-  dependencies:
-    abbrev "1"
 
 nopt@^6.0.0:
   version "6.0.0"
@@ -5198,20 +5091,17 @@ nopt@^6.0.0:
   dependencies:
     abbrev "^1.0.0"
 
+nopt@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/nopt/-/nopt-9.0.0.tgz#6bff0836b2964d24508b6b41b5a9a49c4f4a1f96"
+  integrity sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==
+  dependencies:
+    abbrev "^4.0.0"
+
 normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
-
-npmlog@^6.0.0:
-  version "6.0.2"
-  resolved "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz"
-  integrity sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==
-  dependencies:
-    are-we-there-yet "^3.0.0"
-    console-control-strings "^1.1.0"
-    gauge "^4.0.3"
-    set-blocking "^2.0.0"
 
 object-assign@^4.1.1:
   version "4.1.1"
@@ -5421,6 +5311,11 @@ picomatch@^4.0.3:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
 
+picomatch@^4.0.4:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.5.tgz#51ea57a17d86f605f81039595fbc40ed06a55fab"
+  integrity sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==
+
 pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
@@ -5478,9 +5373,9 @@ postcss@8.5.6, postcss@^8.4.41, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
-prebuild-install@^7.1.1:
+prebuild-install@^7.1.3:
   version "7.1.3"
-  resolved "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz"
+  resolved "https://registry.yarnpkg.com/prebuild-install/-/prebuild-install-7.1.3.tgz#d630abad2b147443f20a212917beae68b8092eec"
   integrity sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==
   dependencies:
     detect-libc "^2.0.0"
@@ -5505,6 +5400,11 @@ proc-log@^2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/proc-log/-/proc-log-2.0.1.tgz"
   integrity sha512-Kcmo2FhfDTXdcbfDH76N7uBYHINxc/8GW7UAVuVP9I+Va3uHSerrnKV6dLooga/gh7GlgzuCCr/eoldnL1muGw==
+
+proc-log@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/proc-log/-/proc-log-6.1.0.tgz#18519482a37d5198e231133a70144a50f21f0215"
+  integrity sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==
 
 progress@^2.0.3:
   version "2.0.3"
@@ -5728,7 +5628,7 @@ read-cache@^1.0.0:
   dependencies:
     pify "^2.3.0"
 
-readable-stream@^3.1.1, readable-stream@^3.4.0, readable-stream@^3.6.0:
+readable-stream@^3.1.1, readable-stream@^3.4.0:
   version "3.6.2"
   resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -5970,11 +5870,6 @@ serialize-error@^7.0.1:
   dependencies:
     type-fest "^0.13.1"
 
-set-blocking@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-  integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
-
 set-cookie-parser@^2.6.0:
   version "2.7.2"
   resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz"
@@ -6068,7 +5963,7 @@ siginfo@^2.0.0:
   resolved "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
-signal-exit@^3.0.2, signal-exit@^3.0.7:
+signal-exit@^3.0.2:
   version "3.0.7"
   resolved "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
@@ -6113,15 +6008,6 @@ smart-buffer@^4.0.2, smart-buffer@^4.2.0:
   resolved "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz"
   integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
 
-socks-proxy-agent@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-6.2.1.tgz"
-  integrity sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==
-  dependencies:
-    agent-base "^6.0.2"
-    debug "^4.3.3"
-    socks "^2.6.2"
-
 socks-proxy-agent@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz"
@@ -6162,24 +6048,17 @@ sprintf-js@^1.1.2:
   resolved "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz"
   integrity sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==
 
-sqlite3@^5.1.7:
-  version "5.1.7"
-  resolved "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz"
-  integrity sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==
+sqlite3@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/sqlite3/-/sqlite3-6.0.1.tgz#c0956e7834931c406b283c87b66771c847a6abfc"
+  integrity sha512-X0czUUMG2tmSqJpEQa3tCuZSHKIx8PwM53vLZzKp/o6Rpy25fiVfjdbnZ988M8+O3ZWR1ih0K255VumCb3MAnQ==
   dependencies:
     bindings "^1.5.0"
-    node-addon-api "^7.0.0"
-    prebuild-install "^7.1.1"
-    tar "^6.1.11"
+    node-addon-api "^8.0.0"
+    prebuild-install "^7.1.3"
+    tar "^7.5.10"
   optionalDependencies:
-    node-gyp "8.x"
-
-ssri@^8.0.0, ssri@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz"
-  integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
-  dependencies:
-    minipass "^3.1.1"
+    node-gyp "12.x"
 
 ssri@^9.0.0:
   version "9.0.1"
@@ -6220,7 +6099,7 @@ stop-iteration-iterator@^1.1.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.1"
 
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -6385,7 +6264,7 @@ tar-stream@^2.1.4:
     inherits "^2.0.3"
     readable-stream "^3.1.1"
 
-tar@^6.0.2, tar@^6.0.5, tar@^6.1.11, tar@^6.1.12, tar@^6.1.2, tar@^6.2.1:
+tar@^6.0.5, tar@^6.1.11, tar@^6.1.12, tar@^6.2.1:
   version "6.2.1"
   resolved "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz"
   integrity sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==
@@ -6396,6 +6275,17 @@ tar@^6.0.2, tar@^6.0.5, tar@^6.1.11, tar@^6.1.12, tar@^6.1.2, tar@^6.2.1:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tar@^7.5.10, tar@^7.5.4:
+  version "7.5.22"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.22.tgz#a696f998136e71487dc3f869a85bba2c67971ba9"
+  integrity sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==
+  dependencies:
+    "@isaacs/fs-minipass" "^4.0.0"
+    chownr "^3.0.0"
+    minipass "^7.1.2"
+    minizlib "^3.1.0"
+    yallist "^5.0.0"
 
 tarn@^3.0.2:
   version "3.0.2"
@@ -6431,6 +6321,14 @@ tinyexec@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz"
   integrity sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==
+
+tinyglobby@^0.2.12:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.17.tgz#562a9a6c9eb2b3b123d39719f9af5bb44fcd7631"
+  integrity sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==
+  dependencies:
+    fdir "^6.5.0"
+    picomatch "^4.0.4"
 
 tinyglobby@^0.2.15:
   version "0.2.15"
@@ -6568,12 +6466,10 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
-unique-filename@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz"
-  integrity sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
-  dependencies:
-    unique-slug "^2.0.0"
+undici@^6.25.0:
+  version "6.28.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.28.0.tgz#9f0e385744fef5021d6596c5bccd783f61193c1c"
+  integrity sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==
 
 unique-filename@^2.0.0:
   version "2.0.1"
@@ -6581,13 +6477,6 @@ unique-filename@^2.0.0:
   integrity sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==
   dependencies:
     unique-slug "^3.0.0"
-
-unique-slug@^2.0.0:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz"
-  integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
-  dependencies:
-    imurmurhash "^0.1.4"
 
 unique-slug@^3.0.0:
   version "3.0.0"
@@ -6781,6 +6670,13 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
+which@^6.0.0:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-6.0.1.tgz#021642443a198fb93b784a5606721cb18cfcbfce"
+  integrity sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==
+  dependencies:
+    isexe "^4.0.0"
+
 why-is-node-running@^2.3.0:
   version "2.3.0"
   resolved "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz"
@@ -6788,13 +6684,6 @@ why-is-node-running@^2.3.0:
   dependencies:
     siginfo "^2.0.0"
     stackback "0.0.2"
-
-wide-align@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz"
-  integrity sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==
-  dependencies:
-    string-width "^1.0.2 || 2 || 3 || 4"
 
 word-wrap@^1.2.5:
   version "1.2.5"
@@ -6857,6 +6746,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yallist@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-5.0.0.tgz#00e2de443639ed0d78fd87de0d27469fbcffb533"
+  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yargs-parser@^21.1.1:
   version "21.1.1"


### PR DESCRIPTION
# Issue
Frontend requires fee calculation for transitions and best solution - calculate fee on backend by dpp bindings

# Things done
- Implemented ipc, which allows to calculate fee of multiple transitions types
- Fixd shielded notes update after broadcast
- bump sdk to version [1.5.0-dev.9](https://github.com/pshenmic/dash-platform-sdk/releases/tag/v1.5.0-dev.9)