### PR TITLE
fix: Disable RPC fallback in P2P mode

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -13,7 +13,6 @@ import IdentitiesPage from "./pages/Identities"
 import AddressesPage from "./pages/Addresses"
 import SettingsPage from "./pages/Settings"
 import { useAuth } from "./contexts/AuthContext"
-import { usePrefetchWalletData } from "./hooks/usePrefetchWalletData"
 import { useDebugMode } from "./hooks/useDebugMode"
 import { ConnectionModeProvider } from "./contexts/ConnectionModeContext"
 import { LOCK_FADE_MS } from "./constants"
@@ -22,8 +21,6 @@ function App(): React.JSX.Element {
   const { isAuthenticated, isLockingOut } = useAuth()
   const location = useLocation()
   const debugMode = useDebugMode()
-
-  usePrefetchWalletData()
 
   if (location.pathname === '/create-wallet') {
     return (

--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -66,7 +66,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
     [wallets]
   )
 
-  const { desired, showSyncUI, fallbackActive, setDesired } = useConnectionModeContext()
+  const { desired, showSyncUI, syncIncomplete, setDesired } = useConnectionModeContext()
 
   const handleWalletChange = (walletId: string): void => {
     if (!walletId || walletId === selectedWallet) return
@@ -101,7 +101,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
             options={connectionOptions}
             value={desired}
             onChange={(value) => setDesired(value as ConnectionType)}
-            syncing={fallbackActive}
+            syncing={syncIncomplete}
           />
           <button
             onMouseEnter={hoverNotification.onMouseEnter}

--- a/src/renderer/src/components/Layout.tsx
+++ b/src/renderer/src/components/Layout.tsx
@@ -9,6 +9,7 @@ import ConnectionSelect from './ui/ConnectionSelect'
 import SyncProgressBar from './ui/SyncProgressBar'
 import SyncControlButton from './ui/SyncControlButton'
 import RefreshButton from './ui/RefreshButton'
+import DataRefreshNotice from './ui/DataRefreshNotice'
 import ScrollIndicator from './ui/ScrollIndicator'
 import WalletUnlockModal from './modal/WalletUnlockModal'
 import { API } from '@renderer/api'
@@ -117,6 +118,7 @@ export default function Layout({ children }: LayoutProps): React.JSX.Element {
       </header>
 
       <main className={"flex-1 mt-12"}>
+        <DataRefreshNotice />
         {children}
       </main>
 

--- a/src/renderer/src/components/pages/dashboard/HeroBalance.tsx
+++ b/src/renderer/src/components/pages/dashboard/HeroBalance.tsx
@@ -1,7 +1,7 @@
-import { Text } from '@renderer/components/dash-ui-kit-enxtended'
+import { Text, Tooltip } from '@renderer/components/dash-ui-kit-enxtended'
 import CreditsAmount from '@renderer/components/ui/CreditsAmount'
 import DashBigNumber from '@renderer/components/ui/DashBigNumber'
-import { dashboardPage } from '@renderer/constants'
+import { dashboardPage, SHIELDED_BALANCE_UNKNOWN_TOOLTIP } from '@renderer/constants'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { useWalletBalance } from '@renderer/hooks/useWalletBalance'
 import { usePlatformCredits } from '@renderer/hooks/usePlatformCredits'
@@ -29,7 +29,8 @@ export default function HeroBalance(): React.JSX.Element {
   const platformCredits = usePlatformCredits(walletId)
   const shieldedCredits = useShieldedCredits(walletId)
   const platformDuffs = creditsToDuffs(platformCredits)
-  const totalDuffs = balance.dash.amount + creditsToDuffs(platformCredits + shieldedCredits)
+  const totalReady = shieldedCredits !== null
+  const totalDuffs = balance.dash.amount + creditsToDuffs(platformCredits + (shieldedCredits ?? 0n))
 
   const blur = isBalanceVisible ? '' : 'blur-sm select-none pointer-events-none'
   const priceRate = rates[currency] ?? 0
@@ -52,11 +53,17 @@ export default function HeroBalance(): React.JSX.Element {
             <div className={"h-11 w-64 rounded-xl animate-pulse bg-dash-primary-dark-blue/8 dark:bg-white/8"} />
           ) : (
             <div className={"flex items-center gap-3.5 flex-wrap"}>
-              <Text size={40} weight={"extrabold"} color={"blue-mint"} className={`leading-[110%] ${blur}`}>
-                <DashBigNumber className={"gap-[.1875rem]!"}>{davToDash(totalDuffs)}</DashBigNumber>
-                {' Dash'}
-              </Text>
-              {rateReady && (
+              {totalReady ? (
+                <Text size={40} weight={"extrabold"} color={"blue-mint"} className={`leading-[110%] ${blur}`}>
+                  <DashBigNumber className={"gap-[.1875rem]!"}>{davToDash(totalDuffs)}</DashBigNumber>
+                  {' Dash'}
+                </Text>
+              ) : (
+                <Tooltip label={SHIELDED_BALANCE_UNKNOWN_TOOLTIP}>
+                  <span className={`text-[2.5rem] font-extrabold leading-[110%] text-dash-orange ${blur}`}>— Dash</span>
+                </Tooltip>
+              )}
+              {totalReady && rateReady && (
                 <span className={`flex items-center rounded-full px-3.5 py-1.5 bg-dash-brand/10 dark:bg-dash-mint/10 ${blur}`}>
                   <Text size={14} weight={"medium"} color={"blue-mint"} className={"whitespace-nowrap"}>
                     ~ {formatFiat(totalDuffs)} {currency.toUpperCase()}

--- a/src/renderer/src/components/pages/dashboard/NetworkCard.tsx
+++ b/src/renderer/src/components/pages/dashboard/NetworkCard.tsx
@@ -59,7 +59,7 @@ export default function NetworkCard(): React.JSX.Element {
 
       <MiniStat label={labels.chainTip} value={tipHeight > 0 ? tipHeight.toLocaleString('en-US') : '—'} />
       <MiniStat label={labels.peers} value={syncActive ? peerCount.toLocaleString('en-US') : '—'} />
-      <MiniStat label={labels.dataSource} value={describeDataSource(readDesired(), sync?.phase)} />
+      <MiniStat label={labels.dataSource} value={describeDataSource(readDesired())} />
     </div>
   )
 }

--- a/src/renderer/src/components/pages/dashboard/Page.tsx
+++ b/src/renderer/src/components/pages/dashboard/Page.tsx
@@ -12,6 +12,7 @@ import {
   TransactionsIcon
 } from '@renderer/components/dash-ui-kit-enxtended/icons'
 import NoResults from '@renderer/components/ui/NoResults'
+import PartialDataNotice from '@renderer/components/ui/PartialDataNotice'
 import { dashboardPage, RECENT_TX_LIMIT } from '@renderer/constants'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { useWalletTransactions, WalletTxItem } from '@renderer/hooks/useWalletTransactions'
@@ -102,6 +103,7 @@ export default function DashboardContent({ onTransactionClick }: DashboardConten
 
   return (
     <div className={"px-12 pb-8 flex flex-col gap-4 phase-fade-in"}>
+      <PartialDataNotice />
       <HeroBalance />
 
       <SectionHeader title={dashboardPage.sections.services} />

--- a/src/renderer/src/components/pages/dashboard/ShieldedCard.tsx
+++ b/src/renderer/src/components/pages/dashboard/ShieldedCard.tsx
@@ -1,10 +1,10 @@
 import { useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Button, Text, ArrowIcon, ShieldSmallIcon } from '@renderer/components/dash-ui-kit-enxtended'
+import { Button, Text, ArrowIcon, ShieldSmallIcon, Tooltip } from '@renderer/components/dash-ui-kit-enxtended'
 import CreditsAmount from '@renderer/components/ui/CreditsAmount'
 import Spinner from '@renderer/components/ui/Spinner'
 import ShieldedUnlockModal from '@renderer/components/modal/ShieldedUnlockModal'
-import { dashboardPage } from '@renderer/constants'
+import { dashboardPage, SHIELDED_BALANCE_UNKNOWN_TOOLTIP } from '@renderer/constants'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { useShieldedNotesInfo, useShieldedPoolInfo, useShieldedStatus, useShieldedSyncState } from '@renderer/hooks/useShielded'
 import { useBalanceVisibility } from '@renderer/hooks/useBalanceVisibility'
@@ -96,15 +96,18 @@ export default function ShieldedCard(): React.JSX.Element {
               <Text size={20} weight={"extrabold"} color={"blue-mint"} className={"leading-[140%]"}>{labels.syncing}</Text>
             </div>
           ) : (
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                setSyncOpen(true)
-              }}
-              className={"self-start cursor-pointer hover:opacity-80 transition-opacity duration-200"}
-            >
-              <Text size={20} weight={"extrabold"} color={"blue-mint"} className={"leading-[140%]"}>{labels.syncBalances}</Text>
-            </button>
+            <Tooltip label={SHIELDED_BALANCE_UNKNOWN_TOOLTIP}>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setSyncOpen(true)
+                }}
+                className={"flex items-baseline gap-2 self-start cursor-pointer hover:opacity-80 transition-opacity duration-200"}
+              >
+                <Text size={20} weight={"extrabold"} className={"leading-[140%] text-dash-orange!"}>— Credits</Text>
+                <Text size={12} weight={"bold"} color={"blue-mint"}>{labels.checkNotes}</Text>
+              </button>
+            </Tooltip>
           )}
         </div>
         {shieldedReady && (syncBusy || (notesInfo.undecodedCount > 0 && !notesLoading)) && (

--- a/src/renderer/src/components/pages/receive/Page.tsx
+++ b/src/renderer/src/components/pages/receive/Page.tsx
@@ -43,7 +43,7 @@ const descriptions: Record<string, React.JSX.Element> = {
 export default function Receive({pageData}: {pageData: ReceivePageType}): React.JSX.Element {
   const [activeTab, setActiveTab] = useState('dash')
   const { status } = useAuth()
-  const { fallbackActive: syncIncomplete } = useConnectionModeContext()
+  const { syncIncomplete } = useConnectionModeContext()
   const walletId = status?.selectedWalletId ?? undefined
   const { data: address } = useAsyncWithCache<string | null>(
     'receiveAddress',

--- a/src/renderer/src/components/pages/settings/Page.tsx
+++ b/src/renderer/src/components/pages/settings/Page.tsx
@@ -13,6 +13,7 @@ import { ZoomPreference, ZOOM_PRESETS } from '@renderer/utils/zoom'
 import { transactionsToCsv, CsvTxRow } from '@renderer/utils/csv'
 import { WalletTxDto } from '@renderer/hooks/useWalletTransactions'
 import { useWallets, refreshWallets } from '@renderer/hooks/useWallets'
+import { invalidateAllAsyncCaches } from '@renderer/hooks/useAsyncWithCache'
 import DeleteWallet from '@renderer/components/modal/DeleteWallet'
 import ExportMnemonic from '@renderer/components/modal/ExportMnemonic'
 
@@ -180,6 +181,7 @@ export default function Settings(): React.JSX.Element {
     setClearPending(true)
     try {
       await API.resetWalletSync(network)
+      invalidateAllAsyncCaches()
     } catch (err) {
       console.error('reset sync failed', err)
     } finally {

--- a/src/renderer/src/components/pages/transactions/TransactionsList.tsx
+++ b/src/renderer/src/components/pages/transactions/TransactionsList.tsx
@@ -8,6 +8,7 @@ import { useWalletTransactions, WalletTxItem } from '@renderer/hooks/useWalletTr
 import { useAuth } from '@renderer/contexts/AuthContext'
 import ListSkeleton from '@renderer/components/ui/Skeleton'
 import NoResults from '@renderer/components/ui/NoResults'
+import PartialDataNotice from '@renderer/components/ui/PartialDataNotice'
 import { davToDashCompact } from '@renderer/utils/balance'
 import {
   DEFAULT_TX_FILTER,
@@ -42,6 +43,7 @@ export default function TransactionsList({ onTransactionClick }: TransactionsLis
       label: title,
       content: (
         <div className={"flex flex-col gap-5 mt-5"}>
+          <PartialDataNotice />
            {loading && (
             <ListSkeleton rows={3} rowClassName="h-[4.25rem] rounded-[.875rem]" />
           )}

--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -102,7 +102,7 @@ export default function TransferHub(): React.JSX.Element {
     return () => { dead = true }
   }, [walletId, wizardKey, fundingRefresh])
 
-  const { fallbackActive: syncIncomplete } = useConnectionModeContext()
+  const { syncIncomplete } = useConnectionModeContext()
   const { format: formatFiat, rateReady } = useFiat()
   const { balance } = useWalletBalance(walletId ?? undefined)
   const { receiving, change } = useAdresses(walletId ?? undefined)

--- a/src/renderer/src/components/sidebar/Balance.tsx
+++ b/src/renderer/src/components/sidebar/Balance.tsx
@@ -1,8 +1,9 @@
 import { DashLogo, useTheme } from "dash-ui-kit/react";
-import { CreditsIcon, ShieldSmallIcon, Text } from "../dash-ui-kit-enxtended";
+import { CreditsIcon, ShieldSmallIcon, Text, Tooltip } from "../dash-ui-kit-enxtended";
 import CreditsAmount from "../ui/CreditsAmount";
 import DashBigNumber from "../ui/DashBigNumber";
 import { davToDash } from "@renderer/utils/balance";
+import { SHIELDED_BALANCE_UNKNOWN_TOOLTIP } from "@renderer/constants";
 import { cva } from "class-variance-authority";
 
 const logoStyles = cva(
@@ -52,7 +53,11 @@ export default function Balance({variant, balance, credits, isVisible, fiat}: {v
       <div className={"flex flex-col gap-[.125rem]"}>
         <Text size={12} weight="medium" color="brand" className={"leading-[120%]"} opacity={50}>{variant === 'dash' ? 'Core Balance:' : variant === 'shielded' ? 'Shielded:' : 'Platform Balance:'}</Text>
         <Text size={16} weight="extrabold" color="brand" className={`${!isVisible ? 'blur-sm select-none pointer-events-none' : ''} leading-[120%]`}>
-          {(variant === 'credits' || variant === 'shielded') && credits != null ? (
+          {variant === 'shielded' && credits == null ? (
+            <Tooltip label={SHIELDED_BALANCE_UNKNOWN_TOOLTIP}>
+              <span className={"text-dash-orange"}>— Credits</span>
+            </Tooltip>
+          ) : (variant === 'credits' || variant === 'shielded') && credits != null ? (
             <CreditsAmount credits={credits} compact unit={"Credits"} amountClassName={"gap-[.125rem]!"} />
           ) : (
             <>

--- a/src/renderer/src/components/sidebar/SidebarHeader.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHeader.tsx
@@ -18,7 +18,7 @@ export default function SidebarHeader(): React.JSX.Element {
   const shieldedSync = useShieldedSyncState(status?.selectedWalletId ?? null)
   const shieldedCredits = shieldedSync.phase === ShieldedSyncPhase.Done && shieldedSync.balance !== null
     ? shieldedSync.balance
-    : 0n
+    : undefined
 
   return (
     <div className={"flex flex-col gap-8 justify-between w-full"}>

--- a/src/renderer/src/components/ui/DataRefreshNotice.tsx
+++ b/src/renderer/src/components/ui/DataRefreshNotice.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react'
+import { Text } from '@renderer/components/dash-ui-kit-enxtended'
+import { RefreshIcon } from '@renderer/components/dash-ui-kit-enxtended/icons'
+import { useAsyncRefreshFailures } from '@renderer/hooks/useAsyncWithCache'
+
+export default function DataRefreshNotice(): React.JSX.Element | null {
+  const { failedCount, retryFailed } = useAsyncRefreshFailures()
+  const [retrying, setRetrying] = useState(false)
+
+  if (failedCount === 0) return null
+
+  const handleRetry = async (): Promise<void> => {
+    if (retrying) return
+    setRetrying(true)
+    try {
+      await retryFailed()
+    } finally {
+      setRetrying(false)
+    }
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={"mx-12 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-[.875rem] dash-block-3 px-4 py-3"}
+    >
+      <div className={"flex items-center gap-2.5"}>
+        <span className={"size-2 shrink-0 rounded-full bg-dash-orange"} />
+        <Text size={12} weight={"medium"} color={"brand"} opacity={70}>
+          Some data could not be refreshed and may be out of date. Check your connection and try again.
+        </Text>
+      </div>
+      <button
+        type="button"
+        onClick={() => { void handleRetry() }}
+        disabled={retrying}
+        className={"flex cursor-pointer items-center gap-2 rounded-[.625rem] px-3 py-1.5 text-dash-brand transition-opacity hover:opacity-75 disabled:cursor-default disabled:opacity-50 dark:text-dash-mint"}
+      >
+        <RefreshIcon size={14} className={retrying ? 'animate-spin' : ''} />
+        <Text size={12} weight={"bold"} color={"blue-mint"}>
+          {retrying ? 'Refreshing...' : 'Try again'}
+        </Text>
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ui/PartialDataNotice.tsx
+++ b/src/renderer/src/components/ui/PartialDataNotice.tsx
@@ -1,0 +1,17 @@
+import { Text } from '@renderer/components/dash-ui-kit-enxtended'
+import { useConnectionModeContext } from '@renderer/contexts/ConnectionModeContext'
+
+export default function PartialDataNotice(): React.JSX.Element | null {
+  const { syncIncomplete } = useConnectionModeContext()
+
+  if (!syncIncomplete) return null
+
+  return (
+    <div className={"flex items-center gap-2 px-3 py-1.5 rounded-[.625rem] dash-block-3 self-start"}>
+      <span className={"size-1.5 rounded-full bg-dash-orange"} />
+      <Text size={12} weight={"medium"} color={"brand"} opacity={50}>
+        Syncing over P2P — balances and transactions may be incomplete
+      </Text>
+    </div>
+  )
+}

--- a/src/renderer/src/components/ui/SyncProgressBar.tsx
+++ b/src/renderer/src/components/ui/SyncProgressBar.tsx
@@ -178,10 +178,9 @@ export default function SyncProgressBar(): React.JSX.Element {
 
         <Text size={10} weight="normal" color="brand" opacity={50}>
           Local node downloads block headers and compact filters to scan your wallet without
-          trusting a third party. While syncing, balances and transactions are served by the
-          Dashscan API as a fallback. When sync completes, the wallet switches to local
-          P2P data automatically. Use the Start / Stop / Restart button in the header to
-          control sync manually.
+          trusting a third party. Balances and transactions remain local while syncing and
+          may be incomplete until the scan finishes. Use the Start / Stop / Restart button
+          in the header to control sync manually.
         </Text>
       </div>
     </div>

--- a/src/renderer/src/constants/dashboardPage.ts
+++ b/src/renderer/src/constants/dashboardPage.ts
@@ -29,6 +29,7 @@ export const dashboardPage = {
     proverPreparing: 'prover preparing…',
     proverError: 'prover error',
     syncBalances: 'Sync balances',
+    checkNotes: 'Check notes',
     syncing: 'Syncing…'
   },
   identities: {

--- a/src/renderer/src/constants/shielded.ts
+++ b/src/renderer/src/constants/shielded.ts
@@ -6,5 +6,7 @@ export const SHIELDED_SYNC_ACTIVE_POLL_MS = 600
 export const SHIELDED_SYNC_IDLE_POLL_MS = 2_500
 export const SHIELDED_NOTES_INFO_CACHE_NS = 'shielded-notes-info'
 export const SHIELDED_SPEND_POLL_MS = 700
+
+export const SHIELDED_BALANCE_UNKNOWN_TOOLTIP = 'Sync shielded notes to load this balance.'
 export const SHIELDED_SPEND_RETRY_MS = 1_000
 export const MAX_SPEND_NOTES = 6

--- a/src/renderer/src/contexts/ConnectionModeContext.tsx
+++ b/src/renderer/src/contexts/ConnectionModeContext.tsx
@@ -1,10 +1,13 @@
 import React, { createContext, useContext } from 'react'
 import { useConnectionMode, UseConnectionMode } from '@renderer/hooks/useConnectionMode'
+import { usePrefetchWalletData } from '@renderer/hooks/usePrefetchWalletData'
 
 const ConnectionModeContext = createContext<UseConnectionMode | null>(null)
 
 export function ConnectionModeProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
   const value = useConnectionMode()
+  usePrefetchWalletData(value.ready)
+  if (!value.ready) return <></>
   return <ConnectionModeContext.Provider value={value}>{children}</ConnectionModeContext.Provider>
 }
 

--- a/src/renderer/src/hooks/useAsyncWithCache.ts
+++ b/src/renderer/src/hooks/useAsyncWithCache.ts
@@ -5,6 +5,7 @@ const inflight = new Map<string, Promise<unknown>>()
 const fetchers = new Map<string, () => Promise<unknown>>()
 const listeners = new Map<string, Set<() => void>>()
 const refreshTimers = new Map<string, { timer: ReturnType<typeof setInterval>; count: number }>()
+let cacheGeneration = 0
 
 function subscribe(cacheKey: string, listener: () => void): () => void {
   const set = listeners.get(cacheKey) ?? new Set()
@@ -26,14 +27,17 @@ function runFetch<T>(cacheKey: string, fetcher: () => Promise<T>): Promise<T> {
   const existing = inflight.get(cacheKey)
   if (existing !== undefined) return existing as Promise<T>
 
+  const generation = cacheGeneration
   const p = fetcher()
     .then((result) => {
-      cache.set(cacheKey, result)
-      notify(cacheKey)
+      if (generation === cacheGeneration) {
+        cache.set(cacheKey, result)
+        notify(cacheKey)
+      }
       return result
     })
     .finally(() => {
-      inflight.delete(cacheKey)
+      if (inflight.get(cacheKey) === p) inflight.delete(cacheKey)
     })
 
   inflight.set(cacheKey, p)
@@ -129,9 +133,10 @@ export function useAsyncWithCache<T>(
       setLoading(true)
     }
 
+    const generation = cacheGeneration
     runFetch(cacheKey, fetcherRef.current)
       .then((result) => {
-        if (dead) return
+        if (dead || generation !== cacheGeneration) return
         setData(result)
       })
       .catch((e) => {
@@ -157,6 +162,13 @@ export function invalidateAsyncCache(namespace: string, key: string): void {
   const cacheKey = `${namespace}:${key}`
   cache.delete(cacheKey)
   notify(cacheKey)
+}
+
+export function invalidateAllAsyncCaches(): void {
+  cacheGeneration++
+  cache.clear()
+  inflight.clear()
+  for (const cacheKey of listeners.keys()) notify(cacheKey)
 }
 
 export function refreshActiveAsyncCaches(): Promise<number> {

--- a/src/renderer/src/hooks/useAsyncWithCache.ts
+++ b/src/renderer/src/hooks/useAsyncWithCache.ts
@@ -1,11 +1,38 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 
 const cache = new Map<string, unknown>()
 const inflight = new Map<string, Promise<unknown>>()
 const fetchers = new Map<string, () => Promise<unknown>>()
 const listeners = new Map<string, Set<() => void>>()
 const refreshTimers = new Map<string, { timer: ReturnType<typeof setInterval>; count: number }>()
+const refreshFailures = new Set<string>()
+const refreshFailureListeners = new Set<() => void>()
 let cacheGeneration = 0
+
+function subscribeRefreshFailures(listener: () => void): () => void {
+  refreshFailureListeners.add(listener)
+  return () => refreshFailureListeners.delete(listener)
+}
+
+function getRefreshFailureCount(): number {
+  return refreshFailures.size
+}
+
+function setRefreshFailure(cacheKey: string, failed: boolean): void {
+  const changed = failed ? !refreshFailures.has(cacheKey) : refreshFailures.has(cacheKey)
+  if (!changed) return
+
+  if (failed) refreshFailures.add(cacheKey)
+  else refreshFailures.delete(cacheKey)
+
+  for (const listener of [...refreshFailureListeners]) listener()
+}
+
+function clearRefreshFailures(): void {
+  if (refreshFailures.size === 0) return
+  refreshFailures.clear()
+  for (const listener of [...refreshFailureListeners]) listener()
+}
 
 function subscribe(cacheKey: string, listener: () => void): () => void {
   const set = listeners.get(cacheKey) ?? new Set()
@@ -32,9 +59,16 @@ function runFetch<T>(cacheKey: string, fetcher: () => Promise<T>): Promise<T> {
     .then((result) => {
       if (generation === cacheGeneration) {
         cache.set(cacheKey, result)
+        setRefreshFailure(cacheKey, false)
         notify(cacheKey)
       }
       return result
+    })
+    .catch((error) => {
+      if (generation === cacheGeneration && refreshTimers.has(cacheKey)) {
+        setRefreshFailure(cacheKey, true)
+      }
+      throw error
     })
     .finally(() => {
       if (inflight.get(cacheKey) === p) inflight.delete(cacheKey)
@@ -63,6 +97,7 @@ function retainRefreshTimer(cacheKey: string, intervalMs: number, fetcher: () =>
     if (current.count <= 0) {
       clearInterval(current.timer)
       refreshTimers.delete(cacheKey)
+      setRefreshFailure(cacheKey, false)
     }
   }
 }
@@ -168,7 +203,29 @@ export function invalidateAllAsyncCaches(): void {
   cacheGeneration++
   cache.clear()
   inflight.clear()
+  clearRefreshFailures()
   for (const cacheKey of listeners.keys()) notify(cacheKey)
+}
+
+async function retryFailedAsyncRefreshes(): Promise<void> {
+  const jobs: Promise<unknown>[] = []
+  for (const cacheKey of [...refreshFailures]) {
+    const fetcher = fetchers.get(cacheKey)
+    if (fetcher !== undefined) jobs.push(runFetch(cacheKey, fetcher))
+  }
+  await Promise.allSettled(jobs)
+}
+
+export function useAsyncRefreshFailures(): {
+  failedCount: number
+  retryFailed: () => Promise<void>
+} {
+  const failedCount = useSyncExternalStore(
+    subscribeRefreshFailures,
+    getRefreshFailureCount,
+    getRefreshFailureCount
+  )
+  return { failedCount, retryFailed: retryFailedAsyncRefreshes }
 }
 
 export function refreshActiveAsyncCaches(): Promise<number> {

--- a/src/renderer/src/hooks/useConnectionMode.ts
+++ b/src/renderer/src/hooks/useConnectionMode.ts
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { API } from '@renderer/api'
 import { ConnectionType, WalletSyncPhase } from '@renderer/api/types'
 import { useAuth } from '@renderer/contexts/AuthContext'
+import { invalidateAllAsyncCaches } from './useAsyncWithCache'
 
 const LS_DESIRED_KEY = 'wallet.connection.desired'
 const CONNECTION_TYPES: readonly ConnectionType[] = ['rpc', 'p2p']
@@ -17,8 +18,9 @@ function isP2pInactive(phase: WalletSyncPhase | undefined): boolean {
 
 export interface UseConnectionMode {
   desired: ConnectionType
+  ready: boolean
   showSyncUI: boolean
-  fallbackActive: boolean
+  syncIncomplete: boolean
   setDesired: (next: ConnectionType) => void
 }
 
@@ -28,27 +30,32 @@ export function useConnectionMode(): UseConnectionMode {
   const walletId = status?.selectedWalletId ?? null
   const activeSyncWalletId = status?.walletSync.walletId ?? null
   const [desired, setDesiredState] = useState<ConnectionType>(readDesired)
+  const [ready, setReady] = useState(false)
 
   const phaseRef = useRef<WalletSyncPhase | undefined>(phase)
   useEffect(() => { phaseRef.current = phase }, [phase])
 
-  const lastApplied = useRef<ConnectionType | null>(null)
   useEffect(() => {
     let cancelled = false
     API.getPreferences()
-      .then(p => { if (!cancelled) lastApplied.current = p.general.connectionType })
-      .catch(() => {})
+      .then(async (preferences) => {
+        const applied = preferences.general.connectionType
+        if (applied !== desired) {
+          const result = await API.setConnectionType(desired)
+          if (!result.success) {
+            localStorage.setItem(LS_DESIRED_KEY, applied)
+            if (!cancelled) setDesiredState(applied)
+          } else {
+            invalidateAllAsyncCaches()
+          }
+        }
+        if (!cancelled) setReady(true)
+      })
+      .catch((err) => {
+        console.error('initialize connection mode failed', err)
+      })
     return () => { cancelled = true }
-  }, [])
-
-  useEffect(() => {
-    if (lastApplied.current === null) return
-    const target: ConnectionType = desired === 'p2p' && phase === WalletSyncPhase.Synced ? 'p2p' : 'rpc'
-    if (target === lastApplied.current) return
-    const previous = lastApplied.current
-    lastApplied.current = target
-    API.setConnectionType(target).catch(() => { lastApplied.current = previous })
-  }, [desired, phase])
+  }, [desired])
 
   const autoStartedFor = useRef<string | null>(null)
   useEffect(() => {
@@ -84,25 +91,33 @@ export function useConnectionMode(): UseConnectionMode {
     return () => { cancelled = true }
   }, [walletId, desired, phase, activeSyncWalletId])
 
+  const pendingMode = useRef<ConnectionType | null>(null)
   const setDesired = useCallback((next: ConnectionType) => {
-    localStorage.setItem(LS_DESIRED_KEY, next)
-    setDesiredState(next)
-    if (next === 'p2p' && walletId && isP2pInactive(phaseRef.current)) {
-      API.startWalletSync(walletId).catch(err => console.error('startWalletSync failed', err))
-    } else if (next === 'rpc' && !isP2pInactive(phaseRef.current)) {
-      API.stopWalletSync().catch(err => console.error('stopWalletSync failed', err))
-    }
-  }, [walletId])
+    if (next === desired || pendingMode.current !== null) return
+    pendingMode.current = next
+    API.setConnectionType(next)
+      .then((result) => {
+        if (!result.success) throw new Error(result.errorMessage ?? 'Failed to set connection mode')
+        invalidateAllAsyncCaches()
+        localStorage.setItem(LS_DESIRED_KEY, next)
+        setDesiredState(next)
+        if (next === 'p2p' && walletId && isP2pInactive(phaseRef.current)) {
+          API.startWalletSync(walletId).catch(err => console.error('startWalletSync failed', err))
+        } else if (next === 'rpc' && !isP2pInactive(phaseRef.current)) {
+          API.stopWalletSync().catch(err => console.error('stopWalletSync failed', err))
+        }
+      })
+      .catch(err => console.error('setConnectionType failed', err))
+      .finally(() => { pendingMode.current = null })
+  }, [desired, walletId])
 
-  const fallbackActive = useMemo(
-    () => desired === 'p2p' && phase !== WalletSyncPhase.Synced,
-    [desired, phase],
-  )
+  const syncIncomplete = desired === 'p2p' && phase !== WalletSyncPhase.Synced
 
   return {
     desired,
+    ready,
     showSyncUI: desired === 'p2p',
-    fallbackActive,
+    syncIncomplete,
     setDesired,
   }
 }

--- a/src/renderer/src/hooks/usePrefetchWalletData.ts
+++ b/src/renderer/src/hooks/usePrefetchWalletData.ts
@@ -6,16 +6,16 @@ import { prefetchPlatformAddresses } from './usePlatformAddresses'
 import { prefetchTransactions } from './useWalletTransactions'
 import { prefetchBalance } from './useWalletBalance'
 
-export function usePrefetchWalletData(): void {
+export function usePrefetchWalletData(enabled = true): void {
   const { isAuthenticated, status } = useAuth()
   const walletId = status?.selectedWalletId ?? null
 
   useEffect(() => {
-    if (!isAuthenticated || !walletId) return
+    if (!enabled || !isAuthenticated || !walletId) return
     prefetchTransactions(walletId)
     prefetchBalance(walletId)
     prefetchAddresses(walletId)
     prefetchPlatformAddresses(walletId)
     prefetchIdentities(walletId)
-  }, [isAuthenticated, walletId])
+  }, [enabled, isAuthenticated, walletId])
 }

--- a/src/renderer/src/hooks/useShielded.ts
+++ b/src/renderer/src/hooks/useShielded.ts
@@ -137,7 +137,7 @@ export function useShieldedSyncState(walletId: string | null | undefined): Shiel
   return state
 }
 
-export function useShieldedCredits(walletId: string | null | undefined): bigint {
+export function useShieldedCredits(walletId: string | null | undefined): bigint | null {
   const { phase, balance } = useShieldedSyncState(walletId)
-  return phase === ShieldedSyncPhase.Done ? balance ?? 0n : 0n
+  return phase === ShieldedSyncPhase.Done ? balance : null
 }

--- a/src/renderer/src/pages/Addresses.tsx
+++ b/src/renderer/src/pages/Addresses.tsx
@@ -6,7 +6,7 @@ import { renderBoldText } from '@renderer/utils/renderBoldText'
 
 export default function AddressesPage(): React.JSX.Element {
   const { description, title } = addressesPage
-  const { fallbackActive: syncIncomplete } = useConnectionModeContext()
+  const { syncIncomplete } = useConnectionModeContext()
 
   return (
     <div className={"flex flex-col"}>

--- a/src/renderer/src/utils/networkStatus.ts
+++ b/src/renderer/src/utils/networkStatus.ts
@@ -1,5 +1,4 @@
 import { ConnectionType, WalletSyncStatus } from '@renderer/api/types'
-import { WalletSyncPhase } from '../enums/WalletSyncPhase'
 
 export type NetworkStatusTone = 'ok' | 'busy' | 'warn'
 
@@ -21,8 +20,8 @@ export function describeNetworkStatus(sync: WalletSyncStatus | undefined): Netwo
   }
 }
 
-export function describeDataSource(desired: ConnectionType, phase: WalletSyncPhase | undefined): string {
-  return desired === 'p2p' && phase === WalletSyncPhase.Synced ? 'Local P2P' : 'Dashscan API'
+export function describeDataSource(desired: ConnectionType): string {
+  return desired === 'p2p' ? 'Local P2P' : 'Dashscan API'
 }
 
 export function formatChange24h(change: number): string {

--- a/tests/unit/asyncCache.test.ts
+++ b/tests/unit/asyncCache.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { invalidateAllAsyncCaches, prefetchAsyncCache } from '@renderer/hooks/useAsyncWithCache'
+
+describe('invalidateAllAsyncCaches', () => {
+  it('forces every cached namespace to fetch again', async () => {
+    let balanceFetches = 0
+    let transactionFetches = 0
+
+    const prefetch = async (): Promise<void> => {
+      await Promise.all([
+        prefetchAsyncCache('test-balance', 'wallet', async () => ++balanceFetches),
+        prefetchAsyncCache('test-transactions', 'wallet', async () => ++transactionFetches),
+      ])
+    }
+
+    await prefetch()
+    await prefetch()
+    expect([balanceFetches, transactionFetches]).toEqual([1, 1])
+
+    invalidateAllAsyncCaches()
+    await prefetch()
+    expect([balanceFetches, transactionFetches]).toEqual([2, 2])
+  })
+})

--- a/tests/unit/asyncCache.test.ts
+++ b/tests/unit/asyncCache.test.ts
@@ -1,5 +1,47 @@
-import { describe, expect, it } from 'vitest'
-import { invalidateAllAsyncCaches, prefetchAsyncCache } from '@renderer/hooks/useAsyncWithCache'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const reactMock = vi.hoisted(() => ({
+  cleanups: [] as Array<() => void>
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react')>()
+  return {
+    ...actual,
+    useEffect: (effect: () => void | (() => void)) => {
+      const cleanup = effect()
+      if (cleanup) reactMock.cleanups.push(cleanup)
+    },
+    useRef: <T>(initial: T) => ({ current: initial }),
+    useState: <T>(initial: T) => [initial, vi.fn()],
+    useSyncExternalStore: (_subscribe: unknown, getSnapshot: () => unknown) => getSnapshot()
+  }
+})
+
+import {
+  invalidateAllAsyncCaches,
+  prefetchAsyncCache,
+  useAsyncRefreshFailures,
+  useAsyncWithCache
+} from '@renderer/hooks/useAsyncWithCache'
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  for (const cleanup of reactMock.cleanups.splice(0).reverse()) cleanup()
+  invalidateAllAsyncCaches()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
 
 describe('invalidateAllAsyncCaches', () => {
   it('forces every cached namespace to fetch again', async () => {
@@ -20,5 +62,97 @@ describe('invalidateAllAsyncCaches', () => {
     invalidateAllAsyncCaches()
     await prefetch()
     expect([balanceFetches, transactionFetches]).toEqual([2, 2])
+  })
+
+  it('clears background refresh failures', async () => {
+    useAsyncWithCache(
+      'failed-refresh',
+      'wallet',
+      async () => Promise.reject(new Error('offline')),
+      0,
+      { refreshIntervalMs: 1_000 }
+    )
+    await flushPromises()
+
+    expect(useAsyncRefreshFailures().failedCount).toBe(1)
+    invalidateAllAsyncCaches()
+    expect(useAsyncRefreshFailures().failedCount).toBe(0)
+  })
+})
+
+describe('background refresh failures', () => {
+  it('tracks only active periodic queries and clears a failure after success', async () => {
+    let failing = true
+    let periodicFetches = 0
+    let foregroundFetches = 0
+
+    useAsyncWithCache(
+      'periodic',
+      'wallet',
+      async () => {
+        periodicFetches++
+        if (failing) throw new Error('offline')
+        return 42
+      },
+      0,
+      { refreshIntervalMs: 1_000 }
+    )
+    useAsyncWithCache(
+      'foreground',
+      'wallet',
+      async () => {
+        foregroundFetches++
+        throw new Error('offline')
+      },
+      0
+    )
+    await flushPromises()
+
+    expect(periodicFetches).toBe(1)
+    expect(foregroundFetches).toBe(1)
+    expect(useAsyncRefreshFailures().failedCount).toBe(1)
+
+    failing = false
+    await useAsyncRefreshFailures().retryFailed()
+
+    expect(periodicFetches).toBe(2)
+    expect(foregroundFetches).toBe(1)
+    expect(useAsyncRefreshFailures().failedCount).toBe(0)
+  })
+
+  it('keeps a failed key failed when retry also fails', async () => {
+    let fetches = 0
+    useAsyncWithCache(
+      'still-failed',
+      'wallet',
+      async () => {
+        fetches++
+        throw new Error('offline')
+      },
+      0,
+      { refreshIntervalMs: 1_000 }
+    )
+    await flushPromises()
+
+    await useAsyncRefreshFailures().retryFailed()
+
+    expect(fetches).toBe(2)
+    expect(useAsyncRefreshFailures().failedCount).toBe(1)
+  })
+
+  it('forgets a failure when the last periodic subscriber is cleaned up', async () => {
+    useAsyncWithCache(
+      'unmounted',
+      'wallet',
+      async () => Promise.reject(new Error('offline')),
+      0,
+      { refreshIntervalMs: 1_000 }
+    )
+    await flushPromises()
+    expect(useAsyncRefreshFailures().failedCount).toBe(1)
+
+    for (const cleanup of reactMock.cleanups.splice(0).reverse()) cleanup()
+
+    expect(useAsyncRefreshFailures().failedCount).toBe(0)
   })
 })

--- a/tests/unit/networkStatus.test.ts
+++ b/tests/unit/networkStatus.test.ts
@@ -32,7 +32,7 @@ describe('describeNetworkStatus', () => {
     expect(describeNetworkStatus(sync({ phase: WalletSyncPhase.Synced }))).toEqual({ label: 'Operational', tone: 'ok' })
   })
 
-  it('is operational when sync is stopped or idle (rpc fallback serves data)', () => {
+  it('is operational when sync is stopped or idle', () => {
     expect(describeNetworkStatus(sync({ phase: WalletSyncPhase.Stopped })).tone).toBe('ok')
     expect(describeNetworkStatus(sync({ phase: WalletSyncPhase.Idle })).tone).toBe('ok')
   })
@@ -57,14 +57,12 @@ describe('describeNetworkStatus', () => {
 })
 
 describe('describeDataSource', () => {
-  it('reports local p2p only when desired and synced', () => {
-    expect(describeDataSource('p2p', WalletSyncPhase.Synced)).toBe('Local P2P')
+  it('reports local p2p whenever p2p is selected', () => {
+    expect(describeDataSource('p2p')).toBe('Local P2P')
   })
 
-  it('reports dashscan otherwise', () => {
-    expect(describeDataSource('p2p', WalletSyncPhase.SyncingHeaders)).toBe('Dashscan API')
-    expect(describeDataSource('p2p', undefined)).toBe('Dashscan API')
-    expect(describeDataSource('rpc', WalletSyncPhase.Synced)).toBe('Dashscan API')
+  it('reports dashscan in rpc mode', () => {
+    expect(describeDataSource('rpc')).toBe('Dashscan API')
   })
 })
 


### PR DESCRIPTION
Prevents Dashscan API reads while P2P mode is selected and invalidates stale cached data on mode changes and P2P reset. Adds incomplete/refresh-error notices and marks Shielded balances unknown until notes are synced.