### PR TITLE
Request unused addresses in different sync modes

### DIFF
--- a/src/main/p2p/SyncService.ts
+++ b/src/main/p2p/SyncService.ts
@@ -9,7 +9,7 @@ import type {CFilterSyncWorkerStatus} from './types/cfilterSync'
 import {P2PAddWatchAddressesMessage, P2PBroadcastMessage, P2PListenMessage, P2PStartMessage, P2PWatchTxsMessage} from './types/messages'
 import {Network} from '../src/types'
 import {BroadcastResult} from './types/broadcast'
-import {AppliedBlock, WalletSyncStatus} from './types/walletSync'
+import {AppliedBlock, GapExhausted, WalletSyncStatus, WatchAddress} from './types/walletSync'
 import {Inventory, Message, Peer} from 'dash-core-p2p'
 import {ChainTipState, PersistedHeader} from './types/chainStore'
 import {SyncServiceEvents} from './types/sync'
@@ -32,7 +32,8 @@ export class SyncService {
   private cfilterSyncWorker: CFilterSyncWorker | null = null
 
   private activeWalletId: string | null = null
-  private activeWatchAddresses: string[] = []
+  private activeWatchAddresses: WatchAddress[] = []
+  private activeGapLimit = 0
   private activeBirthdayHeight = 1
   private activeSeedUtxos: P2PStartMessage['seedUtxos'] = []
   private activeCFilterCursor: number | null = null
@@ -140,6 +141,7 @@ export class SyncService {
 
     this.activeWalletId = cmd.walletId
     this.activeWatchAddresses = cmd.watchAddresses ?? []
+    this.activeGapLimit = cmd.gapLimit
     this.activeBirthdayHeight = cmd.birthdayHeight && cmd.birthdayHeight > 0 ? cmd.birthdayHeight : 1
     this.activeSeedUtxos = cmd.seedUtxos ?? []
     this.activeCFilterCursor = cmd.cfilterCursor ?? null
@@ -217,6 +219,7 @@ export class SyncService {
     await this.teardownBulk()
     this.activeWalletId = null
     this.activeWatchAddresses = []
+    this.activeGapLimit = 0
     this.activeBirthdayHeight = 1
     this.activeSeedUtxos = []
     this.activeCFilterCursor = null
@@ -292,9 +295,9 @@ export class SyncService {
 
   addWatchAddresses = (cmd: P2PAddWatchAddressesMessage): void => {
     if (!this.activeWalletId || cmd.walletId !== this.activeWalletId) return
-    const merged = new Set(this.activeWatchAddresses)
-    for (const a of cmd.addresses) merged.add(a)
-    this.activeWatchAddresses = [...merged]
+    const merged = new Map(this.activeWatchAddresses.map(a => [a.address, a]))
+    for (const a of cmd.addresses) merged.set(a.address, a)
+    this.activeWatchAddresses = [...merged.values()]
     this.cfilterSyncWorker?.addWatchAddresses(cmd.addresses, cmd.rewindToHeight)
   }
 
@@ -463,6 +466,7 @@ export class SyncService {
       chainTipHeight: tipHeight,
       chainTipHashDisplayHex: tipHashDisplayHex,
       watchAddresses: this.activeWatchAddresses,
+      gapLimit: this.activeGapLimit,
       birthdayHeight: this.activeBirthdayHeight,
       seedUtxos: this.activeSeedUtxos,
       cfilterCursor: this.activeCFilterCursor,
@@ -475,6 +479,7 @@ export class SyncService {
     this.cfilterSyncWorker.on('cursorReset', (msg: {walletId: string; height: number}) =>
       this.events.cursorReset(msg.walletId, msg.height)
     )
+    this.cfilterSyncWorker.on('gapExhausted', (gap: GapExhausted) => this.events.gapExhausted(gap))
     this.cfilterSyncWorker.on('error', err =>
       this.handleWorkerError('CFilterSyncWorker', err.message)
     )

--- a/src/main/p2p/constants.ts
+++ b/src/main/p2p/constants.ts
@@ -90,7 +90,7 @@ export const FILTER_TYPE = 0
 // response.
 export const CFILTER_BATCH = 900
 
-export const MAX_INFLIGHT_BATCHES = 6
+export const MAX_INFLIGHT_BATCHES = 10
 
 export const CFCHECKPT_RACE_PEERS = 15
 

--- a/src/main/p2p/index.ts
+++ b/src/main/p2p/index.ts
@@ -40,6 +40,7 @@ const sync = new SyncService({
     process.parentPort.postMessage({type: 'cursorAdvanced', walletId, height}),
   cursorReset: (walletId, height) =>
     process.parentPort.postMessage({type: 'cursorReset', walletId, height}),
+  gapExhausted: gap => process.parentPort.postMessage({type: 'gapExhausted', gap}),
   error: message => process.parentPort.postMessage({type: 'error', message}),
   broadcastResult: (requestId, ok, result, errorMessage) =>
     process.parentPort.postMessage({type: 'broadcastResult', requestId, ok, result, errorMessage}),

--- a/src/main/p2p/types/cfilterSync.ts
+++ b/src/main/p2p/types/cfilterSync.ts
@@ -1,7 +1,7 @@
 import type {Network} from '../../src/types'
 import type {ChainStore} from '../ChainStore'
 import type {PoolService} from '../PoolService'
-import type {WalletSyncUtxo} from './walletSync'
+import type {WalletSyncUtxo, WatchAddress} from './walletSync'
 
 import type {Peer} from 'dash-core-p2p'
 
@@ -25,6 +25,12 @@ export interface PendingCFHeaders {
   stopHeight: number
   triedPeers: Set<Peer>
   raceTimer: ReturnType<typeof setTimeout> | null
+}
+
+// Per-chain view of the derived address range, maintained from the watch set.
+export interface ChainGapState {
+  maxIndex: number
+  lastUsed: number
 }
 
 export type CFilterPhase =
@@ -51,7 +57,8 @@ export interface CFilterSyncWorkerOptions {
   peerPool: PoolService
   chainTipHeight: number
   chainTipHashDisplayHex: string
-  watchAddresses: string[]
+  watchAddresses: WatchAddress[]
+  gapLimit: number
   birthdayHeight: number
   // UTXO seed for the in-memory spend-detection map. Sourced from SQL by
   // main process before sending the start command — the worker never

--- a/src/main/p2p/types/messages.ts
+++ b/src/main/p2p/types/messages.ts
@@ -1,6 +1,6 @@
 import {Network} from '../../src/types'
 import {BroadcastPolicyOverrides, BroadcastResult} from './broadcast'
-import {AppliedBlock, WalletSyncStatus, WalletSyncUtxo} from './walletSync'
+import {AppliedBlock, GapExhausted, WalletSyncStatus, WalletSyncUtxo, WatchAddress} from './walletSync'
 
 // IPC envelopes between the main process and the p2p utility process. P2P* is
 // the envelope; the payload keeps its consumer-side name (WalletSync* /
@@ -13,7 +13,10 @@ export interface P2PStartMessage {
   network: Network
   walletId: string
   chainDbPath: string
-  watchAddresses: string[]
+  watchAddresses: WatchAddress[]
+  // BIP-44 lookahead. The worker holds the scan once fewer than this many
+  // unused addresses remain above the highest used index on either chain.
+  gapLimit: number
   birthdayHeight?: number
   // Shipped in the command rather than read by the worker, so the utility
   // process never touches wallet-scoped storage — SQL stays the source of truth.
@@ -37,7 +40,7 @@ export interface P2PStopMessage {
 export interface P2PAddWatchAddressesMessage {
   type: 'addWatchAddresses'
   walletId: string
-  addresses: string[]
+  addresses: WatchAddress[]
   // Rewinds the cfilter cursor so historical filters re-match the new
   // addresses. Main picks the height — the worker does not decide.
   rewindToHeight?: number
@@ -103,6 +106,14 @@ export interface P2PCursorResetMessage {
   height: number
 }
 
+// The scan is held until main answers with addWatchAddresses. Nothing resumes
+// it on a timer — a silent resume would scan blocks against a watch set already
+// known to be short.
+export interface P2PGapExhaustedMessage {
+  type: 'gapExhausted'
+  gap: GapExhausted
+}
+
 export interface P2PErrorMessage {
   type: 'error'
   message: string
@@ -139,6 +150,7 @@ export type P2PEvent =
   | P2PBlockAppliedMessage
   | P2PCursorAdvancedMessage
   | P2PCursorResetMessage
+  | P2PGapExhaustedMessage
   | P2PErrorMessage
   | P2PBroadcastResultMessage
   | P2PTxInstantLockedMessage

--- a/src/main/p2p/types/sync.ts
+++ b/src/main/p2p/types/sync.ts
@@ -1,5 +1,5 @@
 import type {Network} from '../../src/types'
-import type {AppliedBlock, WalletSyncStatus} from './walletSync'
+import type {AppliedBlock, GapExhausted, WalletSyncStatus} from './walletSync'
 import type {BroadcastResult} from './broadcast'
 
 export interface SyncServiceEvents {
@@ -7,6 +7,7 @@ export interface SyncServiceEvents {
   blockApplied: (block: AppliedBlock) => void
   cursorAdvanced: (walletId: string, height: number) => void
   cursorReset: (walletId: string, height: number) => void
+  gapExhausted: (gap: GapExhausted) => void
   error: (message: string) => void
   broadcastResult: (
     requestId: string,

--- a/src/main/p2p/types/walletSync.ts
+++ b/src/main/p2p/types/walletSync.ts
@@ -51,6 +51,28 @@ export interface WalletSyncStatus {
   updatedAt: number
 }
 
+// ── Watch set ───────────────────────────────────────────────────────────────
+
+// The derivation index travels with the address so the worker can tell, without
+// asking main, whether a block just consumed the last unused address.
+export interface WatchAddress {
+  address: string
+  index: number
+  isChange: boolean
+  isUsed: boolean
+}
+
+// The scan stopped: fewer than gapLimit unused addresses remain above lastUsed
+// on this chain, so blocks past `height` cannot be matched correctly until main
+// derives more. The scan resumes at height + 1, never from genesis.
+export interface GapExhausted {
+  walletId: string
+  height: number
+  isChange: boolean
+  lastUsedIndex: number
+  maxIndex: number
+}
+
 // ── UTXO snapshot ───────────────────────────────────────────────────────────
 
 export interface WalletSyncUtxo {

--- a/src/main/p2p/workers/CFilterSyncWorker.ts
+++ b/src/main/p2p/workers/CFilterSyncWorker.ts
@@ -30,6 +30,7 @@ import type {
   AppliedTxInput,
   AppliedTxOutput,
   WalletSyncUtxo,
+  WatchAddress,
 } from '../types/walletSync'
 import type {
   BlockRequest,
@@ -37,6 +38,7 @@ import type {
   CFilterPhase,
   CFilterSyncWorkerOptions,
   CFilterSyncWorkerStatus,
+  ChainGapState,
   PendingCFHeaders,
 } from '../types/cfilterSync'
 import {
@@ -238,6 +240,16 @@ export class CFilterSyncWorker extends Worker {
   // ── watch set (cfilter inputs) ──────────────────────────────────────────
   private watchedItems: Uint8Array[] = []
   private watchedAddressSet = new Set<string>()
+  private watchedAddressIndex = new Map<string, WatchAddress>()
+  private readonly gapLimit: number
+  private gap: Record<'receiving' | 'change', ChainGapState> = {
+    receiving: {maxIndex: -1, lastUsed: -1},
+    change: {maxIndex: -1, lastUsed: -1},
+  }
+  // Height of the last block applied before the gap ran out. Non-null means the
+  // scan is held and pumpCFilters is a no-op.
+  private gapPausedAt: number | null = null
+  private draining = false
 
   // ── per-phase state ─────────────────────────────────────────────────────
   private cfcheckpt = {
@@ -292,11 +304,9 @@ export class CFilterSyncWorker extends Worker {
     this.birthdayHeight = Math.max(1, opts.birthdayHeight)
     this.seedUtxos = opts.seedUtxos
     this.initialCfilterCursor = opts.cfilterCursor
+    this.gapLimit = opts.gapLimit
 
-    for (const a of opts.watchAddresses) {
-      this.watchedAddressSet.add(a)
-      this.watchedItems.push(p2pkhScript(a))
-    }
+    for (const a of opts.watchAddresses) this.registerWatchAddress(a)
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.M = this.peerPool.messages as any
@@ -363,18 +373,49 @@ export class CFilterSyncWorker extends Worker {
     }
   }
 
+  private registerWatchAddress(a: WatchAddress): boolean {
+    if (this.watchedAddressSet.has(a.address)) return false
+    this.watchedAddressSet.add(a.address)
+    this.watchedAddressIndex.set(a.address, a)
+    this.watchedItems.push(p2pkhScript(a.address))
+    const chain = this.gap[a.isChange ? 'change' : 'receiving']
+    if (a.index > chain.maxIndex) chain.maxIndex = a.index
+    if (a.isUsed && a.index > chain.lastUsed) chain.lastUsed = a.index
+    return true
+  }
+
+  // Fewer than gapLimit unused addresses above the highest used index means a
+  // payment to an address we have not derived can no longer be ruled out.
+  private exhaustedChain(): 'receiving' | 'change' | null {
+    for (const name of ['receiving', 'change'] as const) {
+      const chain = this.gap[name]
+      if (chain.lastUsed + this.gapLimit > chain.maxIndex) return name
+    }
+    return null
+  }
+
   // rewindToHeight set means the addresses may carry past on-chain activity, so
   // historical filters get re-matched. Omitted means main proved them fresh
   // (frontier-derived, or added while synced) and the match set just widens.
-  addWatchAddresses = (addresses: string[], rewindToHeight?: number): void => {
+  addWatchAddresses = (addresses: WatchAddress[], rewindToHeight?: number): void => {
     if (this.stopped) return
     let added = 0
-    for (const a of addresses) {
-      if (this.watchedAddressSet.has(a)) continue
-      this.watchedAddressSet.add(a)
-      this.watchedItems.push(p2pkhScript(a))
-      added++
+    for (const a of addresses) if (this.registerWatchAddress(a)) added++
+
+    if (this.gapPausedAt != null) {
+      const still = this.exhaustedChain()
+      if (still != null) {
+        console.warn(`[cfilter] +${added} address(es) but ${still} gap still short — scan stays held at h=${this.gapPausedAt}`)
+        return
+      }
+      const resumeAt = this.gapPausedAt + 1
+      this.gapPausedAt = null
+      console.log(`[cfilter] gap extended (+${added}, total ${this.watchedAddressSet.size}) — resuming scan at h=${resumeAt}`)
+      this.emitStatus('cfilters')
+      this.pumpCFilters()
+      return
     }
+
     if (added === 0) return
 
     if (rewindToHeight != null) {
@@ -757,8 +798,15 @@ export class CFilterSyncWorker extends Worker {
 
   private startCFilterScan(): void {
     this.cfilter.cursor = Math.max(this.birthdayHeight, this.cfilter.cursor, this.anchorHeight + 1)
-    console.log(`[cfilter] scanning ${this.cfilter.cursor}..${this.effectiveScanTipHeight()}`)
     this.emitStatus('cfilters')
+    // Usage main already knew about can leave the gap short before a single
+    // filter is matched; scanning on would repeat the miss.
+    const exhausted = this.exhaustedChain()
+    if (exhausted != null) {
+      this.holdForGap(exhausted, this.cfilter.cursor - 1)
+      return
+    }
+    console.log(`[cfilter] scanning ${this.cfilter.cursor}..${this.effectiveScanTipHeight()}`)
     this.pumpCFilters()
   }
 
@@ -785,7 +833,7 @@ export class CFilterSyncWorker extends Worker {
   }
 
   private pumpCFilters(): void {
-    if (this.stopped) return
+    if (this.stopped || this.gapPausedAt != null) return
     const effectiveTip = this.effectiveScanTipHeight()
     while (this.cfilter.cursor <= effectiveTip && this.cfilter.inflightBatches.size < MAX_INFLIGHT_BATCHES) {
       const startHeight = this.cfilter.cursor
@@ -812,8 +860,72 @@ export class CFilterSyncWorker extends Worker {
     }
   }
 
+  // Highest height whose matched blocks have all arrived: no request still
+  // outstanding can produce one below it.
+  private settledHeight(): number {
+    let lowest = Infinity
+    for (const b of this.cfilter.inflightBatches.values()) lowest = Math.min(lowest, b.startHeight)
+    for (const r of this.blockFetch.inflight.values()) lowest = Math.min(lowest, r.height)
+    return lowest === Infinity ? this.effectiveScanTipHeight() : lowest - 1
+  }
+
+  // Applied in height order and only up to settledHeight, because spend
+  // detection needs an output recorded before the block spending it. Draining as
+  // the scan runs is what lets gap exhaustion be caught mid-scan rather than
+  // after it — and it keeps matched blocks from piling up in memory.
+  private async drainMatched(): Promise<void> {
+    if (this.draining || this.gapPausedAt != null) return
+    this.draining = true
+    try {
+      const settled = this.settledHeight()
+      const heights = [...this.blockFetch.matched.keys()].filter(h => h <= settled).sort((a, b) => a - b)
+      for (const height of heights) {
+        const block = this.blockFetch.matched.get(height)!
+        this.blockFetch.matched.delete(height)
+        await this.applyBlock(block, height)
+        const exhausted = this.exhaustedChain()
+        if (exhausted != null) {
+          this.holdForGap(exhausted, height)
+          return
+        }
+      }
+      if (settled > 0) this.emit('cursorAdvanced', {walletId: this.walletId, height: settled})
+    } finally {
+      this.draining = false
+    }
+  }
+
+  // Everything above `height` is discarded rather than kept: those blocks were
+  // matched against a watch set now known to be short, and the range is rescanned
+  // from height + 1 once main answers.
+  private holdForGap(chainName: 'receiving' | 'change', height: number): void {
+    const chain = this.gap[chainName]
+    this.gapPausedAt = height
+    for (const b of this.cfilter.inflightBatches.values()) if (b.timer) clearTimeout(b.timer)
+    for (const r of this.blockFetch.inflight.values()) if (r.timer) clearTimeout(r.timer)
+    this.cfilter.inflightBatches.clear()
+    this.cfilterInflightHeights.clear()
+    this.blockFetch.inflight.clear()
+    this.blockFetch.matched.clear()
+    this.cfilter.cursor = height + 1
+    console.log(
+      `[cfilter] ${chainName} gap exhausted at h=${height} ` +
+      `(lastUsed=${chain.lastUsed} maxIndex=${chain.maxIndex} gapLimit=${this.gapLimit}) — ` +
+      'scan held, awaiting new addresses',
+    )
+    this.emit('gapExhausted', {
+      walletId: this.walletId,
+      height,
+      isChange: chainName === 'change',
+      lastUsedIndex: chain.lastUsed,
+      maxIndex: chain.maxIndex,
+    })
+  }
+
   private async maybeDrainAndFinish(): Promise<void> {
     if (this.phase !== 'cfilters') return
+    await this.drainMatched()
+    if (this.gapPausedAt != null) return
     if (this.cfilter.cursor <= this.effectiveScanTipHeight()) return
     if (this.cfilter.inflightBatches.size > 0) return
     if (this.blockFetch.inflight.size > 0) {
@@ -821,13 +933,6 @@ export class CFilterSyncWorker extends Worker {
       console.log(`[cfilters] scan reached tip; waiting on ${waiting.length} block(s): ${waiting.slice(0, 10).join(',')}${waiting.length > 10 ? '…' : ''}`)
       return
     }
-    const sortedHeights = [...this.blockFetch.matched.keys()].sort((a, b) => a - b)
-    for (const h of sortedHeights) {
-      await this.applyBlock(this.blockFetch.matched.get(h)!, h)
-    }
-    this.blockFetch.matched.clear()
-    // Covers the run of unmatched blocks, which produced no blockApplied event
-    // to carry the cursor forward.
     this.emit('cursorAdvanced', {walletId: this.walletId, height: this.effectiveScanTipHeight()})
     this.emitStatus('synced')
     const balance = [...this.utxos.values()].reduce((s, u) => s + BigInt(u.satoshis), 0n)
@@ -863,6 +968,10 @@ export class CFilterSyncWorker extends Worker {
       if (this.phase === 'cfilters') {
         this.emitStatus('cfilters')
         this.pumpCFilters()
+        this.maybeDrainAndFinish().catch(err => {
+          console.error('[cfilter] drain failed:', err)
+          this.reportError(formatChainDbError(err), false)
+        })
       }
     }
   }
@@ -941,6 +1050,11 @@ export class CFilterSyncWorker extends Worker {
         const isMine = !!(address && this.watchedAddressSet.has(address))
         outputs.push({vout, address: address ?? null, satoshis: output.satoshis.toString(), isMine})
         if (!isMine) continue
+        const watched = this.watchedAddressIndex.get(address!)
+        if (watched) {
+          const chain = this.gap[watched.isChange ? 'change' : 'receiving']
+          if (watched.index > chain.lastUsed) chain.lastUsed = watched.index
+        }
         const k = `${txid}:${vout}`
         if (this.utxos.has(k)) continue
         const u: WalletSyncUtxo = {txid, vout, satoshis: output.satoshis.toString(), address: address!, height}

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -152,7 +152,7 @@ export class WalletBackend {
     ipcMain.handle('getPreferences', new GetPreferencesHandler(this.applicationService).handle)
     ipcMain.handle('setLanguage', new SetLanguageHandler(this.applicationService).handle)
     ipcMain.handle('setFiatCurrency', new SetFiatCurrencyHandler(this.applicationService).handle)
-    ipcMain.handle('setConnectionType', new SetConnectionTypeHandler(this.applicationService).handle)
+    ipcMain.handle('setConnectionType', new SetConnectionTypeHandler(this.applicationService, this.walletService).handle)
     ipcMain.handle('resetPreferences', new ResetPreferencesHandler(this.applicationService).handle)
     ipcMain.handle('startWalletSync', new StartWalletSyncHandler(this.walletSyncService).handle)
     ipcMain.handle('stopWalletSync', new StopWalletSyncHandler(this.walletSyncService).handle)

--- a/src/main/src/WalletBackend.ts
+++ b/src/main/src/WalletBackend.ts
@@ -112,7 +112,7 @@ export class WalletBackend {
       throw new Error('Services not initialized. Call start() first.')
     }
 
-    ipcMain.handle('createWallet', new CreateWalletHandler(this.walletService, this.addressDAO, this.walletSyncService, this.shieldedService).handle)
+    ipcMain.handle('createWallet', new CreateWalletHandler(this.walletService, this.shieldedService).handle)
     ipcMain.handle('deleteWallet', new DeleteWalletHandler(this.walletService).handle)
     ipcMain.handle('getAllWallets', new GetAllWalletsHandler(this.walletService).handle)
     ipcMain.handle('selectWallet', new SelectWallet(this.walletService).handle)
@@ -236,6 +236,12 @@ export class WalletBackend {
     this.walletSyncService.onWalletActivity = (walletId) => {
       walletService.discoverCoreAddresses(walletId).catch(err =>
         console.error('[discovery] post-sync address discovery failed:', err))
+    }
+    // The scan is stopped until this answers, so it must not join a discovery
+    // run that started before the block that exhausted the gap was persisted.
+    this.walletSyncService.onGapExhausted = (gap) => {
+      walletService.rediscoverCoreAddresses(gap.walletId).catch(err =>
+        console.error('[discovery] gap-exhausted address discovery failed:', err))
     }
     discoverSelected().catch(err => console.error('[discovery] startup address discovery failed:', err))
     setInterval(() => {

--- a/src/main/src/api/setConnectionType.ts
+++ b/src/main/src/api/setConnectionType.ts
@@ -3,17 +3,22 @@ import {QueryStatus} from "../types/QueryStatus";
 import {ZodError} from "zod";
 import {ConnectionType} from "../preferences/general";
 import {ApplicationService} from "../services/ApplicationService";
+import {WalletService} from "../services/WalletService";
 
 export class SetConnectionTypeHandler {
   private applicationService: ApplicationService
+  private walletService: WalletService
 
-  constructor(applicationService: ApplicationService) {
+  constructor(applicationService: ApplicationService, walletService: WalletService) {
     this.applicationService = applicationService
+    this.walletService = walletService
   }
 
   handle = async (_event: IpcMainInvokeEvent, connectionType: ConnectionType): Promise<QueryStatus> => {
     try {
       const preferences = this.applicationService.preferences
+      const previous = preferences.general.connectionType
+
       await preferences.apply({
         ...preferences,
         general: {
@@ -21,6 +26,17 @@ export class SetConnectionTypeHandler {
           connectionType,
         }
       })
+
+      // The new mode has its own answer to "is this address used" — an SPV store
+      // that never finished syncing hides usage Dashscan can see — so re-run
+      // discovery now rather than waiting for the periodic tick.
+      if (previous !== connectionType) {
+        const selected = await this.walletService.getSelectedWallet()
+        if (selected != null) {
+          this.walletService.rediscoverCoreAddresses(selected.walletId).catch(err =>
+            console.error('[discovery] connection-type switch address discovery failed:', err))
+        }
+      }
 
       return {success: true, errorMessage: null}
     } catch (err) {

--- a/src/main/src/api/wallet/createWallet.ts
+++ b/src/main/src/api/wallet/createWallet.ts
@@ -1,20 +1,14 @@
 import { IpcMainInvokeEvent } from 'electron/utility'
 import { Network } from '../../types'
 import { WalletService } from '../../services/WalletService'
-import { AddressDAO } from '../../database/AddressDAO'
-import { WalletSyncService } from '../../services/WalletSyncService'
 import { ShieldedService } from '../../services/ShieldedService'
 
 export class CreateWalletHandler {
   private walletService: WalletService
-  private addressDAO: AddressDAO
-  private walletSyncService: WalletSyncService
   private shieldedService: ShieldedService
 
-  constructor(walletService: WalletService, addressDAO: AddressDAO, walletSyncService: WalletSyncService, shieldedService: ShieldedService) {
+  constructor(walletService: WalletService, shieldedService: ShieldedService) {
     this.walletService = walletService
-    this.addressDAO = addressDAO
-    this.walletSyncService = walletSyncService
     this.shieldedService = shieldedService
   }
 
@@ -22,11 +16,6 @@ export class CreateWalletHandler {
     const walletId = await this.walletService.createWallet(seedphrase, network, password)
     // Derives and persists the shielded address list for the new wallet.
     await this.shieldedService.getAddresses(walletId, password)
-    // Push the new wallet's addresses into a running wallet sync only if it's
-    // already syncing THIS wallet (per-wallet sync model). 
-    const grouped = await this.addressDAO.getAddressesByWalletId(walletId)
-    const addressList = [...grouped.receiving, ...grouped.change].map(a => a.address)
-    await this.walletSyncService.addWatchAddresses(walletId, addressList)
     return walletId
   }
 }

--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -61,16 +61,16 @@ export const LOCK_WATCH_TTL_MS = 20 * 60 * 1000
 
 // BIP-44 gap limits and the ceiling on each discovery walk. Without a ceiling
 // only the gap can stop the loop.
-export const ADDRESS_LOOKAHEAD = 20
+export const ADDRESS_LOOKAHEAD = 100
 export const IDENTITY_LOOKAHEAD = 10
-export const MAX_DISCOVERY_ROUNDS = 10
+export const MAX_DISCOVERY_ROUNDS = 50
 export const IDENTITY_SCAN_LIMIT = 100
 export const PLATFORM_ADDRESS_LOOKAHEAD = 20
 export const MAX_DISCOVERY_BATCHES = 50
 
 // Bounds how far addAddress derives forward while skipping already-used
 // diversified addresses.
-export const NEW_ADDRESS_LOOKAHEAD_LIMIT = 100
+export const NEW_ADDRESS_LOOKAHEAD_LIMIT = 1000
 
 // How often the backend re-runs address discovery for the selected wallet.
 export const DISCOVERY_INTERVAL_MS = 120_000

--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -61,7 +61,7 @@ export const LOCK_WATCH_TTL_MS = 20 * 60 * 1000
 
 // BIP-44 gap limits and the ceiling on each discovery walk. Without a ceiling
 // only the gap can stop the loop.
-export const ADDRESS_LOOKAHEAD = 100
+export const ADDRESS_LOOKAHEAD = 50
 export const IDENTITY_LOOKAHEAD = 10
 export const MAX_DISCOVERY_ROUNDS = 50
 export const IDENTITY_SCAN_LIMIT = 100

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -353,6 +353,15 @@ export class WalletService {
     return run
   }
 
+  // A run in flight picked its provider when it started, so it is still asking
+  // the old connection mode which addresses are used. Queue a fresh pass behind
+  // it instead of joining it.
+  rediscoverCoreAddresses(walletId: string): Promise<void> {
+    const existing = this.discoveryInflight.get(walletId)
+    if (existing == null) return this.discoverCoreAddresses(walletId)
+    return existing.catch(() => {}).then(() => this.discoverCoreAddresses(walletId))
+  }
+
   private async runCoreDiscovery(walletId: string): Promise<void> {
     const wallet = await this.walletDAO.getWalletById(walletId)
     if (wallet == null || wallet.coreXpub == null) return

--- a/src/main/src/services/WalletService.ts
+++ b/src/main/src/services/WalletService.ts
@@ -329,7 +329,7 @@ export class WalletService {
     if (!key.publicKey) throw new Error(`Failed to derive public key at index ${index}`)
     const address = this.keyPair.p2pkhAddress(key.publicKey, wallet.network)
 
-    await this.addressDAO.insertAddresses([{
+    const row: Address = {
       walletId,
       accountId,
       address,
@@ -338,9 +338,10 @@ export class WalletService {
       isChange,
       isUsed: false,
       label: null
-    }])
+    }
+    await this.addressDAO.insertAddresses([row])
 
-    await this.walletSyncService.addWatchAddresses(walletId, [address], {forwardOnly: true})
+    await this.walletSyncService.addWatchAddresses(walletId, [row], {forwardOnly: true})
 
     return address
   }
@@ -370,7 +371,7 @@ export class WalletService {
     const network = wallet.network
     const provider = this.getProvider(walletId, network)
     const coinType = COIN_TYPE[network]
-    const added: string[] = []
+    const added: Address[] = []
 
     for (const isChange of [false, true]) {
       for (let round = 0; round < MAX_DISCOVERY_ROUNDS; round++) {
@@ -401,7 +402,11 @@ export class WalletService {
           }
         })
         await this.addressDAO.insertAddresses(rows)
-        added.push(...rows.map(r => r.address))
+        added.push(...rows)
+        console.log(
+          `[discovery] ${isChange ? 'change' : 'receiving'} gap exhausted — derived ` +
+          `${rows.length} address(es) at index ${indexes[0]}..${indexes[indexes.length - 1]}`,
+        )
       }
     }
 

--- a/src/main/src/services/WalletSyncService.ts
+++ b/src/main/src/services/WalletSyncService.ts
@@ -2,7 +2,8 @@ import {utilityProcess, UtilityProcess} from 'electron'
 import path from 'path'
 import os from 'os'
 import fs from 'fs'
-import {ChainStorageFilename, HomeFolderName, LOCK_WATCH_TTL_MS} from '../constants'
+import {ADDRESS_LOOKAHEAD, ChainStorageFilename, HomeFolderName, LOCK_WATCH_TTL_MS} from '../constants'
+import {Address} from '../types/Address'
 import {logChildOutput} from '../logger'
 import {WalletDAO} from '../database/WalletDAO'
 import {
@@ -15,7 +16,7 @@ import {AddressDAO} from '../database/AddressDAO'
 import {TransactionDAO} from '../database/TransactionDAO'
 import {P2PCommand, P2PEvent} from '../../p2p/types/messages'
 import {BroadcastPolicyOverrides, BroadcastResult} from '../../p2p/types/broadcast'
-import {AppliedBlock, AppliedTx, WalletSyncStatus, WalletSyncUtxo} from '../../p2p/types/walletSync'
+import {AppliedBlock, AppliedTx, GapExhausted, WalletSyncStatus, WalletSyncUtxo, WatchAddress} from '../../p2p/types/walletSync'
 import {randomUUID} from 'crypto'
 import {GENESIS} from '../../p2p/constants'
 import {QueryStatus} from '../types/QueryStatus'
@@ -63,6 +64,10 @@ export class WalletSyncService {
   private pendingBroadcasts = new Map<string, (event: {ok: boolean; result: BroadcastResult; errorMessage: string | null}) => void>()
   onWalletActivity: ((walletId: string) => void) | null = null
   private activityDebounce: ReturnType<typeof setTimeout> | null = null
+  onGapExhausted: ((gap: GapExhausted) => void) | null = null
+  // Wallets whose scan is held waiting for addresses. The worker resumes at the
+  // held height, so the addresses answering it must not also rewind the cursor.
+  private gapHeld = new Set<string>()
   // txid -> serialized isdlock (hex), feeding InstantAssetLockProof
   // construction for shield / asset-lock funding.
   private instantLocks = new Map<string, string>()
@@ -166,6 +171,16 @@ export class WalletSyncService {
       this.enqueuePersist(() => this.advanceCursorGated(data.walletId, data.height))
     } else if (data.type === 'cursorReset') {
       this.enqueuePersist(() => this.transactionDAO.resetCursor(data.walletId, data.height))
+    } else if (data.type === 'gapExhausted') {
+      this.gapHeld.add(data.gap.walletId)
+      console.log(
+        `[discovery] scan held at h=${data.gap.height}: ${data.gap.isChange ? 'change' : 'receiving'} ` +
+        `lastUsed=${data.gap.lastUsedIndex} maxIndex=${data.gap.maxIndex} — deriving more addresses`,
+      )
+      // After the queued writes for the blocks that caused this, or discovery
+      // reads a SQL state that does not yet show the usage. Not *on* the queue:
+      // the discovery it triggers enqueues its own cursor write.
+      this.persistQueue.catch(() => undefined).then(() => this.onGapExhausted?.(data.gap))
     } else if (data.type === 'broadcastResult') {
       const resolve = this.pendingBroadcasts.get(data.requestId)
       if (resolve) {
@@ -214,8 +229,9 @@ export class WalletSyncService {
 
     // Only this wallet's addresses go into the watch set.
     const grouped = await this.addressDAO.getAddressesByWalletId(walletId)
-    const watchAddresses = [...grouped.receiving, ...grouped.change].map(a => a.address)
+    const watchAddresses = [...grouped.receiving, ...grouped.change].map(toWatchAddress)
 
+    this.gapHeld.delete(walletId)
     this.activeWalletId = walletId
     this.activeNetwork = network
     // The persisted cursor is already capped below any gap, so this scan
@@ -241,6 +257,7 @@ export class WalletSyncService {
       walletId,
       chainDbPath,
       watchAddresses,
+      gapLimit: ADDRESS_LOOKAHEAD,
       seedUtxos,
       cfilterCursor,
       // birthdayHeight is intentionally undefined — defaults to genesis in the
@@ -269,7 +286,7 @@ export class WalletSyncService {
   // is derived, and those addresses may still carry pre-tip history.
   addWatchAddresses = async (
     walletId: string,
-    addresses: string[],
+    addresses: Address[],
     opts: {forwardOnly?: boolean} = {},
   ): Promise<void> => {
     if (addresses.length === 0) return
@@ -277,9 +294,19 @@ export class WalletSyncService {
     if (!wallet) return
     const network = wallet.network as 'mainnet' | 'testnet'
 
+    // A held scan already stopped at the block that exhausted the gap and will
+    // resume from there, so there is nothing behind it left to re-match.
+    const answersHold = this.gapHeld.delete(walletId)
     const scannedOnce = await this.transactionDAO.getInitialScanComplete(walletId)
-    const skipRewind = opts.forwardOnly === true || scannedOnce
+    const skipRewind = answersHold || opts.forwardOnly === true || scannedOnce
     const rewindToHeight = skipRewind ? undefined : GENESIS[network].height
+
+    console.log(
+      `[discovery] watching ${addresses.length} new address(es): ` +
+      (answersHold ? 'resuming held scan'
+        : rewindToHeight == null ? 'forward-only'
+        : `rescanning from h=${rewindToHeight}`),
+    )
 
     if (rewindToHeight != null) {
       // Through the persist queue: applied directly, a cursorAdvanced enqueued
@@ -288,7 +315,7 @@ export class WalletSyncService {
       await this.enqueuePersist(() => this.transactionDAO.resetCursor(walletId, rewindToHeight))
     }
     if (!this.child) return
-    this.send({type: 'addWatchAddresses', walletId, addresses, rewindToHeight})
+    this.send({type: 'addWatchAddresses', walletId, addresses: addresses.map(toWatchAddress), rewindToHeight})
   }
 
   getStatus = (): WalletSyncStatus => {
@@ -614,6 +641,10 @@ export class WalletSyncService {
       updatedAt: Date.now(),
     }
   }
+}
+
+function toWatchAddress(a: Address): WatchAddress {
+  return {address: a.address, index: a.index, isChange: a.isChange, isUsed: a.isUsed}
 }
 
 function txidFromHex(txHex: string): string | undefined {

--- a/tests/api/connectionSwitchDiscovery.test.ts
+++ b/tests/api/connectionSwitchDiscovery.test.ts
@@ -1,0 +1,54 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest'
+import {SetConnectionTypeHandler} from '../../src/main/src/api/setConnectionType'
+import {CreateWalletHandler} from '../../src/main/src/api/wallet/createWallet'
+import {WalletService} from '../../src/main/src/services/WalletService'
+import {ApplicationService} from '../../src/main/src/services/ApplicationService'
+import {WalletDAO} from '../../src/main/src/database/WalletDAO'
+import {harness, PASSWORD, VALID_SEEDPHRASE} from './harness'
+
+describe('connection type switch', () => {
+  let walletService: WalletService
+  let applicationService: ApplicationService
+  let createWalletHandler: CreateWalletHandler
+  let walletDAO: WalletDAO
+  let handler: SetConnectionTypeHandler
+  let rediscover: ReturnType<typeof vi.spyOn>
+
+  beforeEach(async () => {
+    const wired = await harness()
+    walletService = wired.walletService
+    applicationService = wired.applicationService
+    createWalletHandler = wired.createWalletHandler
+    walletDAO = wired.walletDAO
+    // Discovery under 'rpc' would reach the Dashscan API.
+    rediscover = vi.spyOn(walletService, 'rediscoverCoreAddresses').mockResolvedValue(undefined)
+    handler = new SetConnectionTypeHandler(applicationService, walletService)
+  })
+
+  it('rediscovers addresses for the selected wallet when the mode changes', async () => {
+    const walletId = await createWalletHandler.handle(null as never, VALID_SEEDPHRASE, 'testnet', PASSWORD)
+    await walletDAO.setSelectedWallet(walletId)
+
+    const result = await handler.handle(null as never, 'rpc')
+
+    expect(result).toEqual({success: true, errorMessage: null})
+    expect(applicationService.preferences.general.connectionType).toBe('rpc')
+    expect(rediscover).toHaveBeenCalledWith(walletId)
+  })
+
+  it('does not rediscover when the mode is re-applied unchanged', async () => {
+    const walletId = await createWalletHandler.handle(null as never, VALID_SEEDPHRASE, 'testnet', PASSWORD)
+    await walletDAO.setSelectedWallet(walletId)
+
+    await handler.handle(null as never, 'p2p')
+
+    expect(rediscover).not.toHaveBeenCalled()
+  })
+
+  it('still applies the preference with no wallet selected', async () => {
+    const result = await handler.handle(null as never, 'rpc')
+
+    expect(result).toEqual({success: true, errorMessage: null})
+    expect(rediscover).not.toHaveBeenCalled()
+  })
+})

--- a/tests/api/harness.ts
+++ b/tests/api/harness.ts
@@ -65,7 +65,7 @@ export async function harness(): Promise<Harness> {
     transactionDAO,
     walletService,
     applicationService,
-    createWalletHandler: new CreateWalletHandler(walletService, addressDAO, walletSyncService, shieldedService),
+    createWalletHandler: new CreateWalletHandler(walletService, shieldedService),
     request,
   }
 }

--- a/tests/api/harness.ts
+++ b/tests/api/harness.ts
@@ -25,6 +25,7 @@ export interface Harness {
   addressDAO: AddressDAO
   transactionDAO: TransactionDAO
   walletService: WalletService
+  applicationService: ApplicationService
   createWalletHandler: CreateWalletHandler
   request: ReturnType<typeof vi.fn>
 }
@@ -63,6 +64,7 @@ export async function harness(): Promise<Harness> {
     addressDAO,
     transactionDAO,
     walletService,
+    applicationService,
     createWalletHandler: new CreateWalletHandler(walletService, addressDAO, walletSyncService, shieldedService),
     request,
   }

--- a/tests/unit/walletSyncPersistence.test.ts
+++ b/tests/unit/walletSyncPersistence.test.ts
@@ -12,8 +12,20 @@ vi.mock('fs', () => {
 import {WalletSyncService} from '../../src/main/src/services/WalletSyncService'
 import {GENESIS} from '../../src/main/p2p/constants'
 import type {AppliedBlock} from '../../src/main/p2p/types/walletSync'
+import type {Address} from '../../src/main/src/types/Address'
 
 const WALLET = 'wallet-1'
+
+const newAddress = (address: string, index: number): Address => ({
+  walletId: WALLET,
+  accountId: 0,
+  address,
+  derivationPath: `m/44'/1'/0'/0/${index}`,
+  index,
+  isChange: false,
+  isUsed: false,
+  label: null,
+})
 
 const block = (height: number): AppliedBlock => ({
   walletId: WALLET,
@@ -137,7 +149,7 @@ describe('WalletSyncService block persistence', () => {
 
     emit(service, {type: 'blockApplied', block: block(500)})
     emit(service, {type: 'cursorAdvanced', walletId: WALLET, height: 900_000})
-    const rewound = service.addWatchAddresses(WALLET, ['yNewAddr'])
+    const rewound = service.addWatchAddresses(WALLET, [newAddress('yNewAddr', 20)])
     await vi.advanceTimersByTimeAsync(0)
     releaseBlock()
     await settle()
@@ -165,6 +177,41 @@ describe('WalletSyncService block persistence', () => {
     expect(transactionDAO.resetCursor).toHaveBeenLastCalledWith(WALLET, 100)
     expect(transactionDAO.resetCursor.mock.invocationCallOrder[0])
       .toBeGreaterThan(transactionDAO.advanceCursor.mock.invocationCallOrder[0])
+  })
+
+  // The worker stopped at the block that exhausted the gap and resumes from
+  // there. Rewinding on top of that is what used to restart the whole scan.
+  describe('gap-exhausted hold', () => {
+    const gap = {walletId: WALLET, height: 500_000, isChange: false, lastUsedIndex: 51, maxIndex: 100}
+
+    it('does not rewind the cursor for the addresses answering the hold', async () => {
+      emit(service, {type: 'gapExhausted', gap})
+      await settle()
+
+      await service.addWatchAddresses(WALLET, [newAddress('yNewAddr', 101)])
+
+      expect(transactionDAO.resetCursor).not.toHaveBeenCalled()
+    })
+
+    it('notifies main so discovery can run', async () => {
+      const onGapExhausted = vi.fn()
+      service.onGapExhausted = onGapExhausted
+
+      emit(service, {type: 'gapExhausted', gap})
+      await settle()
+
+      expect(onGapExhausted).toHaveBeenCalledWith(gap)
+    })
+
+    it('rewinds again on the next add, once the hold is answered', async () => {
+      emit(service, {type: 'gapExhausted', gap})
+      await settle()
+      await service.addWatchAddresses(WALLET, [newAddress('yNewAddr', 101)])
+
+      await service.addWatchAddresses(WALLET, [newAddress('yLaterAddr', 102)])
+
+      expect(transactionDAO.resetCursor).toHaveBeenCalledExactlyOnceWith(WALLET, GENESIS.testnet.height)
+    })
   })
 
   it('drains queued writes before resetSync wipes the sync data', async () => {


### PR DESCRIPTION
# Issue
Currently wallet has a problem with generation new unused addresses. Basicaly there a different alghoritms and logics for they in different wallet modes (rpc, p2p). For all feature's user must switch wallet modes,

# Things done
- Now we check unused addresses on every mode change
- Updated constants for address discovery
- Updated p2p mechanism for discovery unused addresses