### PR TITLE
Fix wallet deletion bypassing lock screen

### DIFF
--- a/src/renderer/src/api/index.ts
+++ b/src/renderer/src/api/index.ts
@@ -81,8 +81,8 @@ export class API {
     return this.api.estimateTransitionFee(network, query) as Promise<TransitionFeeDto>
   }
 
-  static async deleteWallet(walletId: string) {
-    return this.api.deleteWallet(walletId)
+  static async deleteWallet(walletId: string): Promise<QueryStatus> {
+    return this.api.deleteWallet(walletId) as Promise<QueryStatus>
   }
 
   static async selectWallet(walletId: string) {

--- a/src/renderer/src/components/modal/DeleteWallet.tsx
+++ b/src/renderer/src/components/modal/DeleteWallet.tsx
@@ -5,6 +5,7 @@ import { createPortal } from "react-dom"
 import { Button, CrossIcon, Input, Text } from "../dash-ui-kit-enxtended"
 import { renderBoldText } from "@renderer/utils/renderBoldText"
 import { useTheme } from "dash-ui-kit/react"
+import { useAuth } from "@renderer/contexts/AuthContext"
 
 const DELETE_CONFIRM_TEXT = 'Delete'
 
@@ -12,6 +13,7 @@ export default function DeleteWallet({isDeleteOpen, setIsDeleteOpen, walletToDel
   const [confirmText, setConfirmText] = useState('')
   const [submitAttempted, setSubmitAttempted] = useState(false)
   const {theme} = useTheme()
+  const {lock} = useAuth()
 
   const hasInput = confirmText.trim().length > 0
   const isExactMatch = confirmText.toLowerCase().trim() === DELETE_CONFIRM_TEXT.toLowerCase()
@@ -25,9 +27,13 @@ export default function DeleteWallet({isDeleteOpen, setIsDeleteOpen, walletToDel
     if (!walletToDelete) return
 
     try {
-      await API.deleteWallet(walletToDelete)
+      const result = await API.deleteWallet(walletToDelete)
+      if (!result.success) {
+        throw new Error(result.errorMessage ?? 'Failed to delete wallet')
+      }
       refreshWallets()
       closeDeleteModal()
+      lock()
       toast.error('Wallet deleted')
     } catch (e) {
       console.error(e)


### PR DESCRIPTION
Locks the current session after a wallet is deleted so an automatically selected survivor cannot be opened without its password. Also validates the delete result before locking. Tests: npm run typecheck; npm test -- tests/unit (390 passed).