### PR TITLE
fix: use fixed Core fee for coin selection

### DIFF
--- a/src/main/src/constants.ts
+++ b/src/main/src/constants.ts
@@ -122,12 +122,7 @@ export const HD_VERSIONS: Record<'mainnet' | 'testnet', {private: number; public
 export const ALREADY_IN_CHAIN = 'state transition already in chain'
 
 export const DEFAULT_SELECTION_PARAMS: CoinSelectionParams = {
-  feePerByte: 1n,
-  signedInputSize: 32n + 4n + 8n + 108n + 4n,
-  changeOutputSize: 20n + 4n + 34n + 4n,
-  baseTxSize: 10n,
-  recipientOutputSize: 34n,
-  minFee: 1000n,
+  fee: 10_000n,
 }
 
 export const MIN_OUTPUT_CREDITS = 500_000n

--- a/src/main/src/types/CoinSelection.ts
+++ b/src/main/src/types/CoinSelection.ts
@@ -13,10 +13,5 @@ export interface CoinSelectionResult {
 }
 
 export interface CoinSelectionParams {
-  feePerByte: bigint
-  signedInputSize: bigint
-  changeOutputSize: bigint
-  baseTxSize: bigint
-  recipientOutputSize: bigint
-  minFee: bigint
+  fee: bigint
 }

--- a/src/main/src/utils/coinSelection.ts
+++ b/src/main/src/utils/coinSelection.ts
@@ -1,20 +1,6 @@
 import {CoinSelectionParams, CoinSelectionResult, SelectableUtxo} from '../types/CoinSelection'
 import {DEFAULT_SELECTION_PARAMS} from '../constants'
 
-function estimateFee(
-  inputCount: number,
-  withChange: boolean,
-  params: CoinSelectionParams,
-): bigint {
-  const size =
-    params.baseTxSize +
-    params.signedInputSize * BigInt(inputCount) +
-    params.recipientOutputSize +
-    (withChange ? params.changeOutputSize : 0n)
-  const fee = size * params.feePerByte
-  return fee < params.minFee ? params.minFee : fee
-}
-
 export function selectCoins(
   utxos: SelectableUtxo[],
   target: bigint,
@@ -33,19 +19,9 @@ export function selectCoins(
     selected.push(utxo)
     inputTotal += utxo.satoshis
 
-    // Enough to add a change output worth keeping: charge the with-change fee
-    // and return the remainder as change.
-    const feeWithChange = estimateFee(selected.length, true, params)
-    const change = inputTotal - target - feeWithChange
-    if (change >= params.minFee) {
-      return { inputs: selected, inputTotal, fee: feeWithChange, change }
-    }
-
-    // Not enough for a worthwhile change output, but enough to cover the amount
-    // and the (smaller) no-change fee — drop the dust remainder into the fee.
-    const feeNoChange = estimateFee(selected.length, false, params)
-    if (inputTotal >= target + feeNoChange) {
-      return { inputs: selected, inputTotal, fee: inputTotal - target, change: 0n }
+    const change = inputTotal - target - params.fee
+    if (change >= 0n) {
+      return { inputs: selected, inputTotal, fee: params.fee, change }
     }
   }
 

--- a/tests/unit/coinSelection.test.ts
+++ b/tests/unit/coinSelection.test.ts
@@ -13,7 +13,7 @@ describe('selectCoins', () => {
     const res = selectCoins([utxo(ONE_DASH)], ONE_DASH / 2n)
     expect(res.inputs).toHaveLength(1)
     expect(res.inputTotal).toBe(ONE_DASH)
-    expect(res.fee).toBeGreaterThanOrEqual(DEFAULT_SELECTION_PARAMS.minFee)
+    expect(res.fee).toBe(DEFAULT_SELECTION_PARAMS.fee)
     expect(res.inputTotal).toBe(ONE_DASH / 2n + res.fee + res.change)
   })
 
@@ -53,20 +53,29 @@ describe('selectCoins', () => {
     expect(() => selectCoins([], ONE_DASH)).toThrow('Insufficient funds')
   })
 
-  it('produces a fee at least the minimum relay fee', () => {
+  it('uses the fixed Core network fee', () => {
     const res = selectCoins([utxo(ONE_DASH)], 1000n)
-    expect(res.fee).toBeGreaterThanOrEqual(1000n)
+    expect(res.fee).toBe(DEFAULT_SELECTION_PARAMS.fee)
   })
 
-  it('folds a sub-minFee remainder into the fee instead of making dust change', () => {
-    // total leaves room for the amount + no-change fee, but the leftover after a
-    // with-change fee would be below minFee — so no change output is created and
-    // the remainder is absorbed into the fee.
-    const target = 50_000n
-    const total = target + 1_500n
-    const res = selectCoins([utxo(total)], target)
+  it('sends the maximum balance minus the fixed fee with many inputs', () => {
+    const utxos = Array.from({length: 100}, (_, index) => utxo(20_000n, index))
+    const balance = utxos.reduce((sum, input) => sum + input.satoshis, 0n)
+
+    const res = selectCoins(utxos, balance - DEFAULT_SELECTION_PARAMS.fee)
+
+    expect(res.inputs).toHaveLength(100)
+    expect(res.inputTotal).toBe(balance)
+    expect(res.fee).toBe(DEFAULT_SELECTION_PARAMS.fee)
     expect(res.change).toBe(0n)
-    expect(res.fee).toBe(1_500n)
-    expect(res.inputTotal).toBe(target + res.fee)
+  })
+
+  it('returns change smaller than the fixed fee', () => {
+    const target = 50_000n
+    const total = target + DEFAULT_SELECTION_PARAMS.fee + 1_500n
+    const res = selectCoins([utxo(total)], target)
+    expect(res.change).toBe(1_500n)
+    expect(res.fee).toBe(DEFAULT_SELECTION_PARAMS.fee)
+    expect(res.inputTotal).toBe(target + res.fee + res.change)
   })
 })


### PR DESCRIPTION
## Summary
- make backend coin selection reserve the fixed 10,000-duff Core fee used by the UI
- allow Max sends to consume wallets with many UTXOs
- add a regression test covering a 100-input Max send
