### PR TITLE
fix(send): enter Platform amounts in DASH

### DIFF
--- a/src/renderer/src/api/types.ts
+++ b/src/renderer/src/api/types.ts
@@ -82,7 +82,7 @@ export interface OperationFeeParams extends TransitionFeeParams {
 }
 
 export interface AmountValidationParams {
-  isDashUnit: boolean
+  isCoreOperation: boolean
   amount: string
   operation: TransferOperation | null
   amountDuffs: bigint

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -148,6 +148,7 @@ export default function ShieldedSpendModal({
   const isDone = spend?.phase === ShieldedSpendPhase.Done
   const doneStHash = spend?.stHash ?? null
   const isError = started && spend?.phase === ShieldedSpendPhase.Error
+  const sentCredits = BigInt(sentAmount || amountCredits || '0')
   const confirmLabel = busy ? 'Starting…' : !proverReady ? 'Preparing…' : 'Confirm & Send'
 
   return createPortal(
@@ -281,11 +282,11 @@ export default function ShieldedSpendModal({
             <div className={"flex flex-col items-center text-center mt-5 mb-1"}>
               <div className={"success-pop"}><SuccessIcon size={56} /></div>
               <Text size={16} weight={"extrabold"} color={"brand"} className={"mt-3"}>
-                {spend?.identityId ? 'Identity created' : <CreditsAmount credits={BigInt(sentAmount || amountCredits || '0')} align={"center"} />}
+                {spend?.identityId ? 'Identity created' : <CreditsAmount credits={sentCredits} align={"center"} />}
               </Text>
               <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"mt-1"}>
                 {spend?.identityId
-                  ? `Funded with ${sentAmount || amountCredits} credits from the pool (minus the Platform fee). Re-sync notes to update your balance.`
+                  ? <>Funded with <CreditsAmount credits={sentCredits} showFiat={false} /> from the pool (minus the Platform fee). Re-sync notes to update your balance.</>
                   : 'Broadcast to Platform. Re-sync notes to update your balance.'}
               </Text>
               {successNote && (

--- a/src/renderer/src/components/pages/transfer/TransferHub.tsx
+++ b/src/renderer/src/components/pages/transfer/TransferHub.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { DashLogo } from "dash-ui-kit/react";
-import { Text, CreditsIcon, ShieldSmallIcon } from "@renderer/components/dash-ui-kit-enxtended";
+import { Text, ShieldSmallIcon } from "@renderer/components/dash-ui-kit-enxtended";
 import P2pSyncAlert from "@renderer/components/ui/P2pSyncAlert";
 import ShieldedNotesAlert from "@renderer/components/ui/ShieldedNotesAlert";
 import CreditsAmount from "@renderer/components/ui/CreditsAmount";
@@ -18,7 +18,7 @@ import { useAdresses } from "@renderer/hooks/useAdresses";
 import { useIdentities, prefetchIdentities } from "@renderer/hooks/useIdentities";
 import { useShieldedStatus, useShieldedSyncState } from "@renderer/hooks/useShielded";
 import { useOperationFee } from "@renderer/hooks/useOperationFee";
-import { creditsFromInput, creditsToDuffs, davToDash, davToDashCompact, dashToDuffs, formatCredits } from "@renderer/utils/balance";
+import { creditsToDuffs, davToDash, davToDashCompact, dashToDuffs, duffsToCredits } from "@renderer/utils/balance";
 import { isValidDashAddress } from "@renderer/utils/address";
 import { isValidPlatformAddress } from "@renderer/utils/platformAddress";
 import { isLikelyShieldedAddress } from "@renderer/utils/shieldedAddress";
@@ -184,14 +184,9 @@ export default function TransferHub(): React.JSX.Element {
     : fromKind === SourceKind.Shielded ? (shieldedSpecificNotes != null ? shieldedSpecificNotes.reduce((sum, n) => sum + BigInt(n.amount), 0n) : shieldedBalance)
     : null
 
-  const isDashUnit = info?.unit === 'dash'
-
-  useEffect(() => {
-    setAmount('')
-  }, [isDashUnit])
-
-  const amountDuffs = useMemo(() => (isDashUnit ? dashToDuffs(amount) : 0n), [isDashUnit, amount])
-  const amountCredits = isDashUnit ? 0n : creditsFromInput(amount)
+  const isCoreOperation = fromKind === SourceKind.Core
+  const amountDuffs = useMemo(() => dashToDuffs(amount), [amount])
+  const amountCredits = isCoreOperation ? 0n : duffsToCredits(amountDuffs)
   const minCredits = info?.minCredits ?? 0n
 
   const trimmedTo = toValue.trim()
@@ -213,25 +208,24 @@ export default function TransferHub(): React.JSX.Element {
   })
 
   const sliderMaxAmount = useMemo((): bigint | null => {
-    if (isDashUnit) return balanceDuffs > CORE_FEE_DUFFS ? balanceDuffs - CORE_FEE_DUFFS : 0n
-    if (maxPerTx !== null) return maxPerTx > 0n ? maxPerTx : 0n
+    if (isCoreOperation) return balanceDuffs > CORE_FEE_DUFFS ? balanceDuffs - CORE_FEE_DUFFS : 0n
+    if (maxPerTx !== null) return creditsToDuffs(maxPerTx > 0n ? maxPerTx : 0n)
     if (availableCredits === null || feeCredits === null) return null
     const spendable = availableCredits - feeCredits
-    return spendable > 0n ? spendable : 0n
-  }, [isDashUnit, balanceDuffs, maxPerTx, availableCredits, feeCredits])
+    return creditsToDuffs(spendable > 0n ? spendable : 0n)
+  }, [isCoreOperation, balanceDuffs, maxPerTx, availableCredits, feeCredits])
 
   const sliderPercent = useMemo(() => {
     if (sliderMaxAmount === null || sliderMaxAmount === 0n) return 0
-    const current = isDashUnit ? amountDuffs : amountCredits
-    if (current <= 0n) return 0
-    if (current >= sliderMaxAmount) return 100
-    return Math.max(0, Math.min(100, Math.round(Number(current) * 100 / Number(sliderMaxAmount))))
-  }, [sliderMaxAmount, isDashUnit, amountDuffs, amountCredits])
+    if (amountDuffs <= 0n) return 0
+    if (amountDuffs >= sliderMaxAmount) return 100
+    return Math.max(0, Math.min(100, Math.round(Number(amountDuffs) * 100 / Number(sliderMaxAmount))))
+  }, [sliderMaxAmount, amountDuffs])
 
   const handleSliderPercent = (percent: number): void => {
     if (sliderMaxAmount === null) return
     const value = (sliderMaxAmount * BigInt(percent)) / 100n
-    setAmount(isDashUnit ? davToDash(value) : value.toString())
+    setAmount(davToDash(value))
   }
 
   const sourceReady =
@@ -260,7 +254,7 @@ export default function TransferHub(): React.JSX.Element {
   const coreSourceGated = fromKind === SourceKind.Core && syncIncomplete
   const routeReady = operation != null && sourceReady && destinationReady && !coreSourceGated
 
-  const amountReady = isDashUnit
+  const amountReady = isCoreOperation
     ? amountDuffs > 0n && amountDuffs + CORE_FEE_DUFFS <= balanceDuffs
     : amountCredits >= minCredits && amountCredits > 0n
       && feeCredits !== null
@@ -270,36 +264,28 @@ export default function TransferHub(): React.JSX.Element {
 
   const canSubmit = routeReady && amountReady
 
-  const amountFiat = !rateReady
-    ? undefined
-    : isDashUnit
-      ? amountDuffs > 0n ? formatFiat(amountDuffs) : undefined
-      : amountCredits > 0n ? formatFiat(creditsToDuffs(amountCredits)) : undefined
+  const amountFiat = rateReady && amountDuffs > 0n ? formatFiat(amountDuffs) : undefined
 
   const handleAmount = (e: React.ChangeEvent<HTMLInputElement>): void => {
-    if (isDashUnit) {
-      const val = e.target.value.replace(/[^0-9.]/g, '')
-      const parts = val.split('.')
-      if (parts.length > 2) return
-      if (parts[1] && parts[1].length > 8) return
-      setAmount(val)
-    } else {
-      setAmount(e.target.value.replace(/[^\d]/g, ''))
-    }
+    const val = e.target.value.replace(/[^0-9.]/g, '')
+    const parts = val.split('.')
+    if (parts.length > 2) return
+    if (parts[1] && parts[1].length > 8) return
+    setAmount(val)
   }
 
   const handleMax = (): void => {
-    if (isDashUnit) {
+    if (isCoreOperation) {
       setAmount(davToDash(balanceDuffs > CORE_FEE_DUFFS ? balanceDuffs - CORE_FEE_DUFFS : 0n))
       return
     }
     if (maxPerTx !== null) {
-      setAmount(maxPerTx > 0n ? maxPerTx.toString() : '0')
+      setAmount(davToDash(creditsToDuffs(maxPerTx > 0n ? maxPerTx : 0n)))
       return
     }
     if (availableCredits === null || feeCredits === null) return
     const spendable = availableCredits - feeCredits
-    setAmount(spendable > 0n ? spendable.toString() : '0')
+    setAmount(davToDash(creditsToDuffs(spendable > 0n ? spendable : 0n)))
   }
 
   const destinationPlaceholder =
@@ -309,7 +295,7 @@ export default function TransferHub(): React.JSX.Element {
     : 'shielded address'
 
   const amountError = amountErrorFor({
-    isDashUnit,
+    isCoreOperation,
     amount,
     operation,
     amountDuffs,
@@ -501,11 +487,11 @@ export default function TransferHub(): React.JSX.Element {
             <button
               key={denomination.toString()}
               type={"button"}
-              onClick={() => setAmount(denomination.toString())}
+              onClick={() => setAmount(davToDash(creditsToDuffs(denomination)))}
               className={`px-4 py-2 rounded-[.75rem] cursor-pointer transition-opacity hover:opacity-90 ${amountCredits === denomination ? 'dash-bg-inverse' : 'dash-block-3'}`}
             >
               <Text size={12} weight={"extrabold"} color={amountCredits === denomination ? "blue-mint" : "brand"}>
-                {formatCredits(Number(denomination) / 1e11)} Dash in credits
+                {davToDash(creditsToDuffs(denomination))} Dash
               </Text>
             </button>
           ))}
@@ -515,7 +501,7 @@ export default function TransferHub(): React.JSX.Element {
         value={amount}
         onChange={handleAmount}
         onMax={handleMax}
-        unit={isDashUnit ? <DashLogo size={20} /> : <CreditsIcon size={20} />}
+        unit={<DashLogo size={20} />}
       />
       {operation !== TransferOperation.IdentityCreateFromPool && sliderMaxAmount !== null && (
         <AmountSlider
@@ -530,7 +516,7 @@ export default function TransferHub(): React.JSX.Element {
         </div>
       )}
       <div className={"mt-2 px-1 flex items-center justify-between gap-3"}>
-        {isDashUnit ? (
+        {isCoreOperation ? (
           <Text size={12} weight={"medium"} color={amountDuffs > 0n && amountDuffs > balanceDuffs ? "red" : "brand"} opacity={amountDuffs > 0n && amountDuffs > balanceDuffs ? 100 : 50}>
             {amountDuffs > 0n && amountDuffs > balanceDuffs ? 'Amount exceeds balance' : `Balance: ${davToDashCompact(balanceDuffs)} Dash`}
           </Text>
@@ -543,7 +529,7 @@ export default function TransferHub(): React.JSX.Element {
         )}
         {amountFiat && <Text size={12} weight={"medium"} color={"blue-mint"}>≈ {amountFiat}</Text>}
       </div>
-      {isDashUnit ? (
+      {isCoreOperation ? (
         <div className={"mt-2 px-1 flex items-center justify-between gap-3"}>
           <Text size={12} weight={"medium"} color={"brand"} opacity={50}>Network fee</Text>
           <Text size={12} weight={"medium"} color={"brand"}>{davToDash(CORE_FEE_DUFFS)} Dash</Text>
@@ -595,10 +581,10 @@ export default function TransferHub(): React.JSX.Element {
         <div className={"flex justify-between items-baseline gap-3"}>
           <Text size={12} weight={"medium"} color={"brand"} opacity={50}>Amount</Text>
           <Text size={14} weight={"medium"} color={"brand"}>
-            {isDashUnit ? `${davToDash(amountDuffs)} Dash` : <CreditsAmount credits={amountCredits} align={"end"} />}
+            {isCoreOperation ? `${davToDash(amountDuffs)} Dash` : <CreditsAmount credits={amountCredits} align={"end"} />}
           </Text>
         </div>
-        {isDashUnit ? (
+        {isCoreOperation ? (
           <>
             <div className={"flex justify-between items-baseline gap-3"}>
               <Text size={12} weight={"medium"} color={"brand"} opacity={50}>Network fee</Text>
@@ -623,7 +609,7 @@ export default function TransferHub(): React.JSX.Element {
             </div>
           </>
         )}
-        {isDashUnit && amountFiat && (
+        {amountFiat && (
           <div className={"flex justify-between items-baseline gap-3"}>
             <Text size={12} weight={"medium"} color={"brand"} opacity={50}>≈ Fiat</Text>
             <Text size={12} weight={"medium"} color={"blue-mint"}>{amountFiat}</Text>

--- a/src/renderer/src/utils/amountValidation.ts
+++ b/src/renderer/src/utils/amountValidation.ts
@@ -2,15 +2,15 @@ import { AmountValidationParams } from '../api/types'
 import { TransferOperation } from '../enums/TransferOperation'
 import { MAX_SPEND_NOTES } from '../constants/shielded'
 import { CORE_FEE_DUFFS, SHIELDED_BALANCE_UNKNOWN_ERROR } from '../constants/sendPages'
-import { davToDash, formatCredits } from './balance'
+import { creditsToDuffs, davToDash } from './balance'
 import { isPoolIdentityDenomination } from './transferMatrix'
 
 export function amountErrorFor(params: AmountValidationParams): string | null {
-  const { isDashUnit, amount, operation, amountDuffs, balanceDuffs, amountCredits, minCredits, availableCredits, feeCredits, maxPerTx } = params
+  const { isCoreOperation, amount, operation, amountDuffs, balanceDuffs, amountCredits, minCredits, availableCredits, feeCredits, maxPerTx } = params
 
   if (amount.length === 0) return null
 
-  if (isDashUnit) {
+  if (isCoreOperation) {
     if (amountDuffs <= 0n || amountDuffs + CORE_FEE_DUFFS <= balanceDuffs) return null
     const maxSendableDuffs = balanceDuffs > CORE_FEE_DUFFS ? balanceDuffs - CORE_FEE_DUFFS : 0n
     return `Max sendable is ${davToDash(maxSendableDuffs)} Dash after the network fee.`
@@ -20,18 +20,18 @@ export function amountErrorFor(params: AmountValidationParams): string | null {
     return 'Pick one of the fixed denominations above.'
   }
 
-  if (amountCredits < minCredits) return `Minimum is ${formatCredits(minCredits)} credits.`
+  if (amountCredits < minCredits) return `Minimum is ${davToDash(creditsToDuffs(minCredits))} Dash.`
 
   if (availableCredits === null) return SHIELDED_BALANCE_UNKNOWN_ERROR
 
   if (feeCredits === null) return null
 
   if (amountCredits + feeCredits > availableCredits) {
-    return `Amount plus the ${formatCredits(feeCredits)} credit fee exceeds this balance.`
+    return `Amount plus the ${davToDash(creditsToDuffs(feeCredits))} Dash fee exceeds this balance.`
   }
 
   if (maxPerTx !== null && amountCredits > maxPerTx) {
-    return `Max per transaction right now is ${formatCredits(maxPerTx)} credits (network fee + ${MAX_SPEND_NOTES}-note limit).`
+    return `Max per transaction right now is ${davToDash(creditsToDuffs(maxPerTx))} Dash (network fee + ${MAX_SPEND_NOTES}-note limit).`
   }
 
   return null

--- a/src/renderer/src/utils/balance.ts
+++ b/src/renderer/src/utils/balance.ts
@@ -7,6 +7,10 @@ export function creditsToDuffs(credits: bigint): bigint {
   return sign * (abs / CREDITS_PER_DUFF)
 }
 
+export function duffsToCredits(duffs: bigint): bigint {
+  return duffs * CREDITS_PER_DUFF
+}
+
 export function formatCredits(value: bigint | number): string {
   return value.toLocaleString('en-US')
 }
@@ -52,12 +56,6 @@ export function davToDashCompact(duffs: bigint, maxFractionDigits = 3): string {
     return `${sign}<0.${'0'.repeat(maxFractionDigits - 1)}1`
   }
   return fracStr === '' ? `${sign}${whole}` : `${sign}${whole}.${fracStr}`
-}
-
-export function creditsFromInput(value: string): bigint {
-  const trimmed = value.trim()
-  if (!/^\d+$/.test(trimmed)) return 0n
-  return BigInt(trimmed)
 }
 
 export function dashToDuffs(value: string): bigint {

--- a/src/renderer/src/utils/transferMatrix.ts
+++ b/src/renderer/src/utils/transferMatrix.ts
@@ -51,29 +51,28 @@ export function unsupportedReason(from: SourceKind, to: DestinationKind): string
 interface OperationInfo {
   title: string
   submitLabel: string
-  unit: 'credits' | 'dash'
   minCredits: bigint | null
   spendKind: ShieldedSpendKind | null
 }
 
 const OPERATION_INFO: Record<TransferOperation, OperationInfo> = {
-  [TransferOperation.CoreSend]: {title: 'Send Dash', submitLabel: 'Send', unit: 'dash', minCredits: null, spendKind: null},
-  [TransferOperation.AssetLockFunding]: {title: 'Fund Platform address', submitLabel: 'Fund', unit: 'dash', minCredits: null, spendKind: null},
-  [TransferOperation.AssetLockShield]: {title: 'Shield from L1', submitLabel: 'Shield', unit: 'dash', minCredits: null, spendKind: null},
-  [TransferOperation.IdentityRegister]: {title: 'Register identity', submitLabel: 'Register', unit: 'dash', minCredits: null, spendKind: null},
-  [TransferOperation.IdentityTopUpL1]: {title: 'Top up identity from L1', submitLabel: 'Top up', unit: 'dash', minCredits: null, spendKind: null},
-  [TransferOperation.AddressFundsTransfer]: {title: 'Transfer credits', submitLabel: 'Send', unit: 'credits', minCredits: 500_000n, spendKind: null},
-  [TransferOperation.IdentityTopUp]: {title: 'Top up identity', submitLabel: 'Top up', unit: 'credits', minCredits: 100_000n, spendKind: null},
-  [TransferOperation.IdentityCreate]: {title: 'Create identity', submitLabel: 'Create', unit: 'credits', minCredits: 500_000n, spendKind: null},
-  [TransferOperation.AddressWithdrawal]: {title: 'Withdraw to Core', submitLabel: 'Withdraw', unit: 'credits', minCredits: 100_000n, spendKind: null},
-  [TransferOperation.Shield]: {title: 'Shield credits', submitLabel: 'Shield', unit: 'credits', minCredits: 500_000n, spendKind: null},
-  [TransferOperation.IdentityToAddress]: {title: 'Send from identity', submitLabel: 'Send', unit: 'credits', minCredits: 500_000n, spendKind: null},
-  [TransferOperation.IdentityToIdentity]: {title: 'Send to identity', submitLabel: 'Send', unit: 'credits', minCredits: 100_000n, spendKind: null},
-  [TransferOperation.IdentityWithdrawal]: {title: 'Withdraw from identity', submitLabel: 'Withdraw', unit: 'credits', minCredits: 100_000n, spendKind: null},
-  [TransferOperation.ShieldedTransfer]: {title: 'Shielded send', submitLabel: 'Send', unit: 'credits', minCredits: 500_000n, spendKind: ShieldedSpendKind.Transfer},
-  [TransferOperation.Unshield]: {title: 'Unshield', submitLabel: 'Unshield', unit: 'credits', minCredits: 500_000n, spendKind: ShieldedSpendKind.Unshield},
-  [TransferOperation.ShieldedWithdrawal]: {title: 'Withdraw to L1', submitLabel: 'Withdraw', unit: 'credits', minCredits: 500_000n, spendKind: ShieldedSpendKind.Withdrawal},
-  [TransferOperation.IdentityCreateFromPool]: {title: 'Create identity from pool', submitLabel: 'Create', unit: 'credits', minCredits: 10_000_000_000n, spendKind: ShieldedSpendKind.IdentityCreate},
+  [TransferOperation.CoreSend]: {title: 'Send Dash', submitLabel: 'Send', minCredits: null, spendKind: null},
+  [TransferOperation.AssetLockFunding]: {title: 'Fund Platform address', submitLabel: 'Fund', minCredits: null, spendKind: null},
+  [TransferOperation.AssetLockShield]: {title: 'Shield from L1', submitLabel: 'Shield', minCredits: null, spendKind: null},
+  [TransferOperation.IdentityRegister]: {title: 'Register identity', submitLabel: 'Register', minCredits: null, spendKind: null},
+  [TransferOperation.IdentityTopUpL1]: {title: 'Top up identity from L1', submitLabel: 'Top up', minCredits: null, spendKind: null},
+  [TransferOperation.AddressFundsTransfer]: {title: 'Transfer credits', submitLabel: 'Send', minCredits: 500_000n, spendKind: null},
+  [TransferOperation.IdentityTopUp]: {title: 'Top up identity', submitLabel: 'Top up', minCredits: 100_000n, spendKind: null},
+  [TransferOperation.IdentityCreate]: {title: 'Create identity', submitLabel: 'Create', minCredits: 500_000n, spendKind: null},
+  [TransferOperation.AddressWithdrawal]: {title: 'Withdraw to Core', submitLabel: 'Withdraw', minCredits: 100_000n, spendKind: null},
+  [TransferOperation.Shield]: {title: 'Shield credits', submitLabel: 'Shield', minCredits: 500_000n, spendKind: null},
+  [TransferOperation.IdentityToAddress]: {title: 'Send from identity', submitLabel: 'Send', minCredits: 500_000n, spendKind: null},
+  [TransferOperation.IdentityToIdentity]: {title: 'Send to identity', submitLabel: 'Send', minCredits: 100_000n, spendKind: null},
+  [TransferOperation.IdentityWithdrawal]: {title: 'Withdraw from identity', submitLabel: 'Withdraw', minCredits: 100_000n, spendKind: null},
+  [TransferOperation.ShieldedTransfer]: {title: 'Shielded send', submitLabel: 'Send', minCredits: 500_000n, spendKind: ShieldedSpendKind.Transfer},
+  [TransferOperation.Unshield]: {title: 'Unshield', submitLabel: 'Unshield', minCredits: 500_000n, spendKind: ShieldedSpendKind.Unshield},
+  [TransferOperation.ShieldedWithdrawal]: {title: 'Withdraw to L1', submitLabel: 'Withdraw', minCredits: 500_000n, spendKind: ShieldedSpendKind.Withdrawal},
+  [TransferOperation.IdentityCreateFromPool]: {title: 'Create identity from pool', submitLabel: 'Create', minCredits: 10_000_000_000n, spendKind: ShieldedSpendKind.IdentityCreate},
 }
 
 export function operationInfo(operation: TransferOperation): OperationInfo {

--- a/tests/unit/amountValidation.test.ts
+++ b/tests/unit/amountValidation.test.ts
@@ -6,10 +6,10 @@ import { SHIELDED_BALANCE_UNKNOWN_ERROR } from '../../src/renderer/src/constants
 
 function params(overrides: Partial<AmountValidationParams> = {}): AmountValidationParams {
   return {
-    isDashUnit: false,
-    amount: '1000000',
+    isCoreOperation: false,
+    amount: '0.00001',
     operation: TransferOperation.AddressFundsTransfer,
-    amountDuffs: 0n,
+    amountDuffs: 1_000n,
     balanceDuffs: 0n,
     amountCredits: 1_000_000n,
     minCredits: 500_000n,
@@ -23,7 +23,7 @@ function params(overrides: Partial<AmountValidationParams> = {}): AmountValidati
 describe('amountErrorFor', () => {
   it('accepts a Dash amount with room for the fixed network fee', () => {
     expect(amountErrorFor(params({
-      isDashUnit: true,
+      isCoreOperation: true,
       amount: '0.9999',
       amountDuffs: 99_990_000n,
       balanceDuffs: 100_000_000n,
@@ -33,7 +33,7 @@ describe('amountErrorFor', () => {
 
   it('reports the max Dash amount after the fixed network fee', () => {
     expect(amountErrorFor(params({
-      isDashUnit: true,
+      isCoreOperation: true,
       amount: '1',
       amountDuffs: 100_000_000n,
       balanceDuffs: 100_000_000n,
@@ -65,7 +65,7 @@ describe('amountErrorFor', () => {
   })
 
   it('reports the operation minimum', () => {
-    expect(amountErrorFor(params({amountCredits: 499_999n}))).toBe('Minimum is 500,000 credits.')
+    expect(amountErrorFor(params({amountCredits: 499_999n}))).toBe('Minimum is 0.000005 Dash.')
   })
 
   it('reports an unknown shielded balance', () => {
@@ -78,12 +78,12 @@ describe('amountErrorFor', () => {
 
   it('reports amount plus fee exceeding the balance', () => {
     const error = amountErrorFor(params({amountCredits: 900_000_000n, feeCredits: 100_000n, availableCredits: 900_000_000n}))
-    expect(error).toBe('Amount plus the 100,000 credit fee exceeds this balance.')
+    expect(error).toBe('Amount plus the 0.000001 Dash fee exceeds this balance.')
   })
 
   it('reports the per-transaction cap', () => {
     const error = amountErrorFor(params({amountCredits: 800_000_000n, maxPerTx: 700_000_000n}))
-    expect(error).toBe('Max per transaction right now is 700,000,000 credits (network fee + 6-note limit).')
+    expect(error).toBe('Max per transaction right now is 0.007 Dash (network fee + 6-note limit).')
   })
 
   it('is silent when the amount fits the balance, the fee and the cap', () => {
@@ -91,6 +91,6 @@ describe('amountErrorFor', () => {
   })
 
   it('prefers the minimum over the balance complaint', () => {
-    expect(amountErrorFor(params({amountCredits: 1n, availableCredits: 0n}))).toBe('Minimum is 500,000 credits.')
+    expect(amountErrorFor(params({amountCredits: 1n, availableCredits: 0n}))).toBe('Minimum is 0.000005 Dash.')
   })
 })

--- a/tests/unit/balance.test.ts
+++ b/tests/unit/balance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { davToDash, davToDashCompact, dashToDuffs, formatCompactCredits, creditsToDuffs, creditsFromInput } from '../../src/renderer/src/utils/balance'
+import { creditsToDuffs, davToDash, davToDashCompact, dashToDuffs, duffsToCredits, formatCompactCredits } from '../../src/renderer/src/utils/balance'
 
 const ONE_DASH = 100_000_000n
 
@@ -15,22 +15,30 @@ describe('creditsToDuffs', () => {
     expect(creditsToDuffs(1_999n)).toBe(1n)
     expect(creditsToDuffs(-1_999n)).toBe(-1n)
   })
+
+  it('rounds a credit balance down to a spend-safe DASH amount', () => {
+    for (const credits of [999n, 1_000n, 1_999n, 500_999n, 100_000_000_999n]) {
+      expect(duffsToCredits(creditsToDuffs(credits))).toBeLessThanOrEqual(credits)
+    }
+  })
 })
 
-describe('creditsFromInput', () => {
-  it('parses whole credit amounts', () => {
-    expect(creditsFromInput('500000')).toBe(500_000n)
-    expect(creditsFromInput('100000000000')).toBe(100_000_000_000n)
-    expect(creditsFromInput('0')).toBe(0n)
-    expect(creditsFromInput(' 42 ')).toBe(42n)
+describe('duffsToCredits', () => {
+  it('converts each duff to 1000 credits', () => {
+    expect(duffsToCredits(1n)).toBe(1_000n)
+    expect(duffsToCredits(ONE_DASH)).toBe(100_000_000_000n)
+    expect(duffsToCredits(0n)).toBe(0n)
   })
 
-  it('returns 0 for non-integer input', () => {
-    expect(creditsFromInput('')).toBe(0n)
-    expect(creditsFromInput('1.5')).toBe(0n)
-    expect(creditsFromInput('abc')).toBe(0n)
-    expect(creditsFromInput('-5')).toBe(0n)
-    expect(creditsFromInput('1e6')).toBe(0n)
+  it('round-trips whole-duff credit amounts', () => {
+    for (const credits of [1_000n, 500_000n, 100_000_000_000n]) {
+      expect(duffsToCredits(creditsToDuffs(credits))).toBe(credits)
+    }
+  })
+
+  it('converts a DASH input into the Platform protocol amount', () => {
+    expect(duffsToCredits(dashToDuffs('1.25'))).toBe(125_000_000_000n)
+    expect(duffsToCredits(dashToDuffs('0.00000001'))).toBe(1_000n)
   })
 })
 

--- a/tests/unit/transferMatrix.test.ts
+++ b/tests/unit/transferMatrix.test.ts
@@ -13,6 +13,7 @@ import { SourceKind } from '../../src/renderer/src/enums/SourceKind'
 import { DestinationKind } from '../../src/renderer/src/enums/DestinationKind'
 import { TransferOperation } from '../../src/renderer/src/enums/TransferOperation'
 import { ShieldedSpendKind } from '../../src/renderer/src/enums/ShieldedSpendKind'
+import { creditsToDuffs, duffsToCredits } from '../../src/renderer/src/utils/balance'
 
 const SPEND_KINDS: Array<ShieldedSpendKind | null> = [...Object.values(ShieldedSpendKind), null]
 
@@ -85,18 +86,18 @@ describe('unsupportedReason', () => {
 })
 
 describe('operationInfo', () => {
-  it('exposes the credits unit and minimum for platform operations', () => {
-    expect(operationInfo(TransferOperation.AddressFundsTransfer)).toMatchObject({unit: 'credits', minCredits: 500_000n})
+  it('exposes the credit minimum for platform operations', () => {
+    expect(operationInfo(TransferOperation.AddressFundsTransfer)).toMatchObject({minCredits: 500_000n})
     expect(operationInfo(TransferOperation.AddressWithdrawal).minCredits).toBe(100_000n)
     expect(operationInfo(TransferOperation.IdentityWithdrawal).minCredits).toBe(100_000n)
     expect(operationInfo(TransferOperation.IdentityTopUp).minCredits).toBe(100_000n)
-    expect(operationInfo(TransferOperation.IdentityToIdentity)).toMatchObject({unit: 'credits', minCredits: 100_000n})
+    expect(operationInfo(TransferOperation.IdentityToIdentity)).toMatchObject({minCredits: 100_000n})
   })
 
-  it('uses dash units for L1-sourced operations', () => {
-    expect(operationInfo(TransferOperation.CoreSend)).toMatchObject({unit: 'dash', minCredits: null})
-    expect(operationInfo(TransferOperation.AssetLockShield)).toMatchObject({unit: 'dash', minCredits: null})
-    expect(operationInfo(TransferOperation.IdentityTopUpL1)).toMatchObject({unit: 'dash', minCredits: null, submitLabel: 'Top up'})
+  it('does not require credit minimums for L1-sourced operations', () => {
+    expect(operationInfo(TransferOperation.CoreSend)).toMatchObject({minCredits: null})
+    expect(operationInfo(TransferOperation.AssetLockShield)).toMatchObject({minCredits: null})
+    expect(operationInfo(TransferOperation.IdentityTopUpL1)).toMatchObject({minCredits: null, submitLabel: 'Top up'})
   })
 
   it('maps every pool-paid operation to its spend kind', () => {
@@ -132,7 +133,13 @@ describe('isPoolIdentityDenomination', () => {
   })
 
   it('matches the pool minimum in operationInfo', () => {
-    expect(operationInfo(TransferOperation.IdentityCreateFromPool)).toMatchObject({unit: 'credits', minCredits: POOL_IDENTITY_DENOMINATIONS[0]})
+    expect(operationInfo(TransferOperation.IdentityCreateFromPool)).toMatchObject({minCredits: POOL_IDENTITY_DENOMINATIONS[0]})
+  })
+
+  it('represents every denomination exactly as a DASH input', () => {
+    for (const denomination of POOL_IDENTITY_DENOMINATIONS) {
+      expect(duffsToCredits(creditsToDuffs(denomination))).toBe(denomination)
+    }
   })
 })
 


### PR DESCRIPTION
Closes #87

Platform and shielded transfer amounts are now entered in DASH and converted to Credits at the API boundary. Max, slider, validation, fixed denominations, fiat display, and confirmation use the DASH-facing amount consistently. Credits remain available on hover in amount displays.
