### PR TITLE
fix: place explorer links next to transaction hashes

### DIFF
--- a/src/renderer/src/components/modal/AssetLockFundingModal.tsx
+++ b/src/renderer/src/components/modal/AssetLockFundingModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon } from '../dash-ui-kit-enxtended'
 import { useTheme } from 'dash-ui-kit/react'
 import { API } from '@renderer/api'
 import { AssetLockFundingKind, AssetLockFundingState } from '@renderer/api/types'
@@ -11,7 +11,7 @@ import HashField from '@renderer/components/ui/HashField'
 import CopyableError from '@renderer/components/ui/CopyableError'
 import CopyButton from '@renderer/components/ui/CopyButton'
 import { useAuth } from '@renderer/contexts/AuthContext'
-import { transactionUrl, platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
+import { transactionUrl, platformTransactionUrl } from '@renderer/utils/explorer'
 import { ASSET_LOCK_FUNDING_POLL_MS } from '@renderer/constants'
 
 interface AssetLockFundingModalProps {
@@ -355,29 +355,10 @@ export default function AssetLockFundingModal({
                   </div>
                 </div>
               )}
-              {state.stHash && (
-                <div className={"flex justify-between items-center gap-4"}>
-                  <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"shrink-0"}>State transition</Text>
-                  <div className={"flex items-center gap-2 min-w-0"}>
-                    <Text size={12} weight={"medium"} color={"brand"} className={"font-mono min-w-0 break-all text-right"}>{state.stHash}</Text>
-                    <CopyButton text={state.stHash} className={"shrink-0"} />
-                  </div>
-                </div>
-              )}
+              {doneTxid && <HashField hash={doneTxid} label={"L1 transaction hash"} explorerUrl={network ? transactionUrl(doneTxid, network) : null} />}
+              {doneStHash && <HashField hash={doneStHash} label={"L2 state transition hash"} explorerUrl={network ? platformTransactionUrl(doneStHash, network) : null} />}
             </div>
             <div className={"mt-4.5 flex gap-2"}>
-              {doneTxid && network && (
-                <Button type={"button"} onClick={() => openExternal(transactionUrl(doneTxid, network))} variant={"outline"} colorScheme={"primary-light"} size={"sm"} className={"flex-1 rounded-[.9375rem] gap-2 px-3 whitespace-nowrap"}>
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  L1 explorer
-                </Button>
-              )}
-              {doneStHash && network && (
-                <Button type={"button"} onClick={() => openExternal(platformTransactionUrl(doneStHash, network))} variant={"outline"} colorScheme={"primary-light"} size={"sm"} className={"flex-1 rounded-[.9375rem] gap-2 px-3 whitespace-nowrap"}>
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  Platform explorer
-                </Button>
-              )}
               <Button type={"button"} onClick={onClose} variant={"solid"} colorScheme={"lightBlue-mint"} size={"sm"} className={"flex-1 rounded-[.9375rem]"}>
                 Done
               </Button>

--- a/src/renderer/src/components/modal/SendConfirmModal.tsx
+++ b/src/renderer/src/components/modal/SendConfirmModal.tsx
@@ -322,19 +322,6 @@ export default function SendConfirmModal({
             </div>
 
             <div className={"mt-4.5 flex gap-2"}>
-              {result?.txid && network && (
-                <Button
-                  type={"button"}
-                  onClick={() => openExternal(transactionUrl(result.txid, network))}
-                  variant={"outline"}
-                  colorScheme={"primary-light"}
-                  size={"sm"}
-                  className={"flex-1 rounded-[.9375rem] gap-2"}
-                >
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  View on explorer
-                </Button>
-              )}
               <Button
                 type={"button"}
                 onClick={onClose}

--- a/src/renderer/src/components/modal/ShieldConfirmModal.tsx
+++ b/src/renderer/src/components/modal/ShieldConfirmModal.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, ShieldSmallIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, ShieldSmallIcon } from '../dash-ui-kit-enxtended'
 import { useTheme } from 'dash-ui-kit/react'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { API } from '@renderer/api'
 import { ShieldResult } from '@renderer/api/types'
-import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
+import { platformTransactionUrl } from '@renderer/utils/explorer'
 import { ConfirmModalPhase } from '@renderer/enums/ConfirmModalPhase'
 import Spinner from '@renderer/components/ui/Spinner'
 import CopyableError from '@renderer/components/ui/CopyableError'
@@ -210,23 +210,10 @@ export default function ShieldConfirmModal({
                 <Text size={12} weight={"medium"} color={"brand"} opacity={50} className={"shrink-0"}>From</Text>
                 <Text size={12} weight={"medium"} color={"brand"} className={"font-mono min-w-0 break-all text-right"}>{result?.fromAddress}</Text>
               </div>
-              {result?.stHash && <HashField hash={result.stHash} />}
+              {result?.stHash && <HashField hash={result.stHash} explorerUrl={network ? platformTransactionUrl(result.stHash, network) : null} />}
             </div>
 
             <div className={"mt-4.5 flex gap-2"}>
-              {result?.stHash && network && (
-                <Button
-                  type={"button"}
-                  onClick={() => openExternal(platformTransactionUrl(result.stHash, network))}
-                  variant={"outline"}
-                  colorScheme={"primary-light"}
-                  size={"sm"}
-                  className={"flex-1 rounded-[.9375rem] gap-2"}
-                >
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  View on explorer
-                </Button>
-              )}
               <Button
                 type={"button"}
                 onClick={onClose}

--- a/src/renderer/src/components/modal/ShieldedSpendModal.tsx
+++ b/src/renderer/src/components/modal/ShieldedSpendModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon, CheckIcon } from '../dash-ui-kit-enxtended'
 import { ExclamationIcon } from '../dash-ui-kit-enxtended/icons'
 import HashField from '@renderer/components/ui/HashField'
 import CopyableError from '@renderer/components/ui/CopyableError'
@@ -9,7 +9,7 @@ import { useTheme } from 'dash-ui-kit/react'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { API } from '@renderer/api'
 import { ShieldedSpendState } from '@renderer/api/types'
-import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
+import { platformTransactionUrl } from '@renderer/utils/explorer'
 import { ShieldedSpendPhase } from '@renderer/enums/ShieldedSpendPhase'
 import Spinner from '@renderer/components/ui/Spinner'
 import { SHIELDED_SPEND_POLL_MS, SHIELDED_SPEND_RETRY_MS } from '@renderer/constants'
@@ -146,7 +146,6 @@ export default function ShieldedSpendModal({
   }
 
   const isDone = spend?.phase === ShieldedSpendPhase.Done
-  const doneStHash = spend?.stHash ?? null
   const isError = started && spend?.phase === ShieldedSpendPhase.Error
   const sentCredits = BigInt(sentAmount || amountCredits || '0')
   const confirmLabel = busy ? 'Starting…' : !proverReady ? 'Preparing…' : 'Confirm & Send'
@@ -300,15 +299,9 @@ export default function ShieldedSpendModal({
             </div>
             <div className={"mt-5 flex flex-col gap-[.75rem] p-[.875rem] rounded-[.9375rem] dash-block-3"}>
               {spend?.identityId && <HashField hash={spend.identityId} label={"Identity"} />}
-              {spend?.stHash && <HashField hash={spend.stHash} />}
+              {spend?.stHash && <HashField hash={spend.stHash} explorerUrl={network ? platformTransactionUrl(spend.stHash, network) : null} />}
             </div>
             <div className={"mt-4.5 flex gap-2"}>
-              {doneStHash && network && (
-                <Button type={"button"} onClick={() => openExternal(platformTransactionUrl(doneStHash, network))} variant={"outline"} colorScheme={"primary-light"} size={"sm"} className={"flex-1 rounded-[.9375rem] gap-2"}>
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  View on explorer
-                </Button>
-              )}
               <Button type={"button"} onClick={onClose} variant={"solid"} colorScheme={"lightBlue-mint"} size={"sm"} className={"flex-1 rounded-[.9375rem]"}>
                 Done
               </Button>

--- a/src/renderer/src/components/modal/TransferConfirmModal.tsx
+++ b/src/renderer/src/components/modal/TransferConfirmModal.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 import { createPortal } from 'react-dom'
-import { Button, CrossIcon, Input, Text, SuccessIcon, ExternalLinkIcon } from '../dash-ui-kit-enxtended'
+import { Button, CrossIcon, Input, Text, SuccessIcon } from '../dash-ui-kit-enxtended'
 import { ExclamationIcon } from '../dash-ui-kit-enxtended/icons'
 import { useTheme } from 'dash-ui-kit/react'
 import { useAuth } from '@renderer/contexts/AuthContext'
 import { PlatformSendResult } from '@renderer/api/types'
 import { ConfirmModalPhase } from '@renderer/enums/ConfirmModalPhase'
-import { platformTransactionUrl, openExternal } from '@renderer/utils/explorer'
+import { platformTransactionUrl } from '@renderer/utils/explorer'
 import Spinner from '@renderer/components/ui/Spinner'
 import CopyableError from '@renderer/components/ui/CopyableError'
 import HashField from '@renderer/components/ui/HashField'
@@ -204,23 +204,10 @@ export default function TransferConfirmModal({
                   <Text size={12} weight={"medium"} color={"brand"}><CreditsAmount credits={result.feeCredits} align={"end"} /></Text>
                 </div>
               )}
-              {result?.stHash && <HashField hash={result.stHash} />}
+              {result?.stHash && <HashField hash={result.stHash} explorerUrl={network ? platformTransactionUrl(result.stHash, network) : null} />}
             </div>
 
             <div className={"mt-4.5 flex gap-2"}>
-              {result?.stHash && network && (
-                <Button
-                  type={"button"}
-                  onClick={() => openExternal(platformTransactionUrl(result.stHash, network))}
-                  variant={"outline"}
-                  colorScheme={"primary-light"}
-                  size={"sm"}
-                  className={"flex-1 rounded-[.9375rem] gap-2"}
-                >
-                  <ExternalLinkIcon size={16} color={"currentColor"} className={"dash-text-default"} />
-                  View on explorer
-                </Button>
-              )}
               <Button
                 type={"button"}
                 onClick={onClose}

--- a/src/renderer/src/components/ui/HashField.tsx
+++ b/src/renderer/src/components/ui/HashField.tsx
@@ -41,7 +41,7 @@ export default function HashField({ hash, label = 'State transition hash', explo
         {explorerUrl && (
           <button onClick={() => openExternal(explorerUrl)} className={"cursor-pointer flex items-center gap-1 hover:opacity-60"}>
             <ExternalLinkIcon size={10} color={"currentColor"} className={"dash-text-default opacity-70"} />
-            <Text size={10} weight={"medium"} color={"brand"} opacity={40}>View on Dashscan</Text>
+            <Text size={10} weight={"medium"} color={"brand"} opacity={40}>View on explorer</Text>
           </button>
         )}
       </div>


### PR DESCRIPTION
Moves explorer actions beside each transaction hash and removes the large footer buttons. Bridge results show separate L1 and L2 hashes with matching explorer links. Closes #86.